### PR TITLE
[fix]: GitFlowGuideのグラフィカル表示をReactFlowで実装

### DIFF
--- a/container/claudecode/studyGIt/package.json
+++ b/container/claudecode/studyGIt/package.json
@@ -15,7 +15,8 @@
     "react-dom": "^18.2.0",
     "isomorphic-git": "^1.24.5",
     "styled-components": "^6.1.8",
-    "framer-motion": "^10.16.16"
+    "framer-motion": "^10.16.16",
+    "reactflow": "^11.10.1"
   },
   "devDependencies": {
     "@types/node": "^20.10.6",

--- a/container/claudecode/studyGIt/src/components/GitFlowGuide.js
+++ b/container/claudecode/studyGIt/src/components/GitFlowGuide.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
+import ReactFlowGitGraph from './ReactFlowGitGraph';
 import styles from './GitFlowGuide.module.css';
 
 const GitFlowGuide = () => {
@@ -73,26 +74,7 @@ module.exports = app;`}
             </div>
           ) : (
             <div className={styles.graphicView}>
-              <div className={styles.gitGraph}>
-                <div className={styles.branchRow}>
-                  <div className={styles.branchName + ' ' + styles.branchNameMain}>main/master<br/>(本番B面)</div>
-                  <div className={styles.graphBranch + ' ' + styles.graphBranchMain}>
-                    <div className={styles.graphCommit} style={{ left: '200px' }} />
-                  </div>
-                </div>
-                <div className={styles.graphArrow} 
-                     style={{ position: 'absolute', left: '210px', top: '16px', height: '40px', width: '2px', backgroundColor: '#3498db', zIndex: 1 }}>
-                  <div className={styles.arrowHead} 
-                       style={{ position: 'absolute', bottom: '-5px', left: '-4px', borderWidth: '5px', borderStyle: 'solid', borderColor: 'transparent transparent #3498db transparent', transform: 'rotate(0deg)' }} />
-                </div>
-                <div className={styles.branchRow}>
-                  <div className={styles.branchName + ' ' + styles.branchNameDevelop}>develop<br/>(開発A面)</div>
-                  <div className={styles.graphBranch + ' ' + styles.graphBranchDevelop}>
-                    <div className={styles.graphCommit} style={{ left: '200px' }} />
-                    <div className={styles.graphCommitLabel} style={{ position: 'absolute', top: '-30px', left: '180px', fontSize: '10px', color: '#666' }}>初期コミット</div>
-                  </div>
-                </div>
-              </div>
+              <ReactFlowGitGraph step={1} animationEnabled={animationEnabled} />
             </div>
           )}
         </div>
@@ -173,33 +155,7 @@ module.exports = {
             </div>
           ) : (
             <div className={styles.graphicView}>
-              <div className={styles.gitGraph}>
-                <div className={styles.branchRow}>
-                  <div className={styles.branchName + ' ' + styles.branchNameMain}>main/master<br/>(本番B面)</div>
-                  <div className={styles.graphBranch + ' ' + styles.graphBranchMain}>
-                    <div className={styles.graphCommit} style={{ left: '200px' }} />
-                  </div>
-                </div>
-                <div className={styles.branchRow}>
-                  <div className={styles.branchName + ' ' + styles.branchNameDevelop}>develop<br/>(開発A面)</div>
-                  <div className={styles.graphBranch + ' ' + styles.graphBranchDevelop}>
-                    <div className={styles.graphCommit} style={{ left: '200px' }} />
-                    <div className={styles.graphCommitLabel} style={{ position: 'absolute', top: '-30px', left: '180px', fontSize: '10px', color: '#666' }}>初期化</div>
-                  </div>
-                </div>
-                <div className={styles.graphArrow} 
-                     style={{ position: 'absolute', left: '210px', top: '76px', height: '30px', width: '2px', backgroundColor: '#2ecc71' }}>
-                  <div className={styles.arrowHead} 
-                       style={{ position: 'absolute', bottom: '-5px', left: '-4px', borderWidth: '5px', borderStyle: 'solid', borderColor: 'transparent transparent #2ecc71 transparent', transform: 'rotate(0deg)' }} />
-                </div>
-                <div className={styles.branchRow}>
-                  <div className={styles.branchName + ' ' + styles.branchNameFeature}>feature/<br/>login-system</div>
-                  <div className={styles.graphBranch + ' ' + styles.graphBranchFeature} style={{ width: '200px', left: '150px' }}>
-                    <div className={styles.graphCommit} style={{ left: '50px' }} />
-                    <div className={styles.graphCommitLabel} style={{ position: 'absolute', top: '-30px', left: '30px', fontSize: '10px', color: '#666' }}>ログイン機能実装</div>
-                  </div>
-                </div>
-              </div>
+              <ReactFlowGitGraph step={2} animationEnabled={animationEnabled} />
             </div>
           )}
         </div>
@@ -282,33 +238,7 @@ module.exports = {
             </div>
           ) : (
             <div className={styles.graphicView}>
-              <div className={styles.gitGraph}>
-                <div className={styles.branchRow}>
-                  <div className={styles.branchName + ' ' + styles.branchNameMain}>main/master<br/>(本番B面)</div>
-                  <div className={styles.graphBranch + ' ' + styles.graphBranchMain}>
-                    <div className={styles.graphCommit} style={{ left: '200px' }} />
-                  </div>
-                </div>
-                <div className={styles.branchRow}>
-                  <div className={styles.branchName + ' ' + styles.branchNameDevelop}>develop<br/>(開発A面)</div>
-                  <div className={styles.graphBranch + ' ' + styles.graphBranchDevelop}>
-                    <div className={styles.graphCommit} style={{ left: '200px' }} />
-                    <div className={styles.graphCommit} style={{ left: '300px' }} />
-                    <div className={styles.graphCommitLabel} style={{ position: 'absolute', top: '-30px', left: '280px', fontSize: '10px', color: '#666' }}>feature/login-systemをマージ</div>
-                  </div>
-                </div>
-                <div className={styles.branchRow}>
-                  <div className={styles.branchName + ' ' + styles.branchNameFeature}>feature/<br/>login-system</div>
-                  <div className={styles.graphBranch + ' ' + styles.graphBranchFeature} style={{ width: '110px', left: '180px' }}>
-                    <div className={styles.graphCommit} style={{ left: '100px' }} />
-                  </div>
-                </div>
-                <div className={styles.graphArrow} 
-                     style={{ position: 'absolute', left: '280px', top: '100px', height: '60px', width: '2px', transform: 'rotate(-45deg)', backgroundColor: '#2ecc71', zIndex: 1 }}>
-                  <div className={styles.arrowHead} 
-                       style={{ position: 'absolute', top: '-5px', left: '-4px', borderWidth: '5px', borderStyle: 'solid', borderColor: '#2ecc71 transparent transparent transparent', transform: 'rotate(0deg)' }} />
-                </div>
-              </div>
+              <ReactFlowGitGraph step={3} animationEnabled={animationEnabled} />
             </div>
           )}
         </div>
@@ -396,33 +326,7 @@ module.exports = {
             </div>
           ) : (
             <div className={styles.graphicView}>
-              <div className={styles.gitGraph}>
-                <div className={styles.branchRow}>
-                  <div className={styles.branchName + ' ' + styles.branchNameMain}>main/master<br/>(本番B面)</div>
-                  <div className={styles.graphBranch + ' ' + styles.graphBranchMain}>
-                    <div className={styles.graphCommit} style={{ left: '200px' }} />
-                  </div>
-                </div>
-                <div className={styles.branchRow}>
-                  <div className={styles.branchName + ' ' + styles.branchNameDevelop}>develop<br/>(開発A面)</div>
-                  <div className={styles.graphBranch + ' ' + styles.graphBranchDevelop}>
-                    <div className={styles.graphCommit} style={{ left: '200px' }} />
-                    <div className={styles.graphCommit} style={{ left: '300px' }} />
-                  </div>
-                </div>
-                <div className={styles.graphArrow} 
-                     style={{ position: 'absolute', left: '310px', top: '56px', height: '40px', width: '2px', backgroundColor: '#2ecc71', zIndex: 1 }}>
-                  <div className={styles.arrowHead} 
-                       style={{ position: 'absolute', bottom: '-5px', left: '-4px', borderWidth: '5px', borderStyle: 'solid', borderColor: 'transparent transparent #2ecc71 transparent', transform: 'rotate(0deg)' }} />
-                </div>
-                <div className={styles.branchRow}>
-                  <div className={styles.branchName + ' ' + styles.branchNameFeature}>feature/<br/>user-profile</div>
-                  <div className={styles.graphBranch + ' ' + styles.graphBranchFeature} style={{ width: '100px', left: '250px' }}>
-                    <div className={styles.graphCommit} style={{ left: '50px' }} />
-                    <div className={styles.graphCommitLabel} style={{ position: 'absolute', top: '-30px', left: '30px', fontSize: '10px', color: '#666' }}>プロファイル機能実装</div>
-                  </div>
-                </div>
-              </div>
+              <ReactFlowGitGraph step={4} animationEnabled={animationEnabled} />
             </div>
           )}
         </div>
@@ -512,33 +416,7 @@ module.exports = {
             </div>
           ) : (
             <div className={styles.graphicView}>
-              <div className={styles.gitGraph}>
-                <div className={styles.branchRow}>
-                  <div className={styles.branchName + ' ' + styles.branchNameMain}>main/master<br/>(本番B面)</div>
-                  <div className={styles.graphBranch + ' ' + styles.graphBranchMain}>
-                    <div className={styles.graphCommit} style={{ left: '200px' }} />
-                  </div>
-                </div>
-                <div className={styles.branchRow}>
-                  <div className={styles.branchName + ' ' + styles.branchNameDevelop}>develop<br/>(開発A面)</div>
-                  <div className={styles.graphBranch + ' ' + styles.graphBranchDevelop}>
-                    <div className={styles.graphCommit} style={{ left: '200px' }} />
-                    <div className={styles.graphCommit} style={{ left: '280px' }} />
-                    <div className={styles.graphCommit} style={{ left: '380px' }} />
-                  </div>
-                </div>
-                <div className={styles.branchRow}>
-                  <div className={styles.branchName + ' ' + styles.branchNameFeature}>feature/<br/>user-profile</div>
-                  <div className={styles.graphBranch + ' ' + styles.graphBranchFeature} style={{ width: '110px', left: '260px' }}>
-                    <div className={styles.graphCommit} style={{ left: '100px' }} />
-                  </div>
-                </div>
-                <div className={styles.graphArrow} 
-                     style={{ position: 'absolute', left: '360px', top: '100px', height: '60px', width: '2px', transform: 'rotate(-45deg)', backgroundColor: '#2ecc71', zIndex: 1 }}>
-                  <div className={styles.arrowHead} 
-                       style={{ position: 'absolute', top: '-5px', right: '-4px', borderWidth: '5px', borderStyle: 'solid', borderColor: '#2ecc71 transparent transparent transparent', transform: 'rotate(45deg)' }} />
-                </div>
-              </div>
+              <ReactFlowGitGraph step={5} animationEnabled={animationEnabled} />
             </div>
           )}
         </div>
@@ -619,33 +497,7 @@ module.exports = app;`}
             </div>
           ) : (
             <div className={styles.graphicView}>
-              <div className={styles.gitGraph}>
-                <div className={styles.branchRow}>
-                  <div className={styles.branchName + ' ' + styles.branchNameMain}>main/master<br/>(本番B面)</div>
-                  <div className={styles.graphBranch + ' ' + styles.graphBranchMain}>
-                    <div className={styles.graphCommit} style={{ left: '200px' }} />
-                  </div>
-                </div>
-                <div className={styles.branchRow}>
-                  <div className={styles.branchName + ' ' + styles.branchNameDevelop}>develop<br/>(開発A面)</div>
-                  <div className={styles.graphBranch + ' ' + styles.graphBranchDevelop}>
-                    <div className={styles.graphCommit} style={{ left: '200px' }} />
-                    <div className={styles.graphCommit} style={{ left: '280px' }} />
-                    <div className={styles.graphCommit} style={{ left: '380px' }} />
-                  </div>
-                </div>
-                <div className={styles.graphArrow} 
-                     style={{ position: 'absolute', left: '390px', top: '56px', height: '40px', width: '2px', backgroundColor: '#f39c12', zIndex: 1 }}>
-                  <div className={styles.arrowHead} 
-                       style={{ position: 'absolute', bottom: '-5px', left: '-4px', borderWidth: '5px', borderStyle: 'solid', borderColor: 'transparent transparent #f39c12 transparent', transform: 'rotate(0deg)' }} />
-                </div>
-                <div className={styles.branchRow}>
-                  <div className={styles.branchName + ' ' + styles.branchNameRelease}>release/<br/>1.0.0</div>
-                  <div className={styles.graphBranch + ' ' + styles.graphBranchRelease} style={{ width: '50px', left: '360px' }}>
-                    <div className={styles.graphCommit} style={{ left: '40px' }} />
-                  </div>
-                </div>
-              </div>
+              <ReactFlowGitGraph step={6} animationEnabled={animationEnabled} />
             </div>
           )}
         </div>
@@ -707,29 +559,7 @@ module.exports = {
             </div>
           ) : (
             <div className={styles.graphicView}>
-              <div className={styles.gitGraph}>
-                <div className={styles.branchRow}>
-                  <div className={styles.branchName + ' ' + styles.branchNameMain}>main/master<br/>(本番B面)</div>
-                  <div className={styles.graphBranch + ' ' + styles.graphBranchMain}>
-                    <div className={styles.graphCommit} style={{ left: '200px' }} />
-                  </div>
-                </div>
-                <div className={styles.branchRow}>
-                  <div className={styles.branchName + ' ' + styles.branchNameDevelop}>develop<br/>(開発A面)</div>
-                  <div className={styles.graphBranch + ' ' + styles.graphBranchDevelop}>
-                    <div className={styles.graphCommit} style={{ left: '200px' }} />
-                    <div className={styles.graphCommit} style={{ left: '280px' }} />
-                    <div className={styles.graphCommit} style={{ left: '380px' }} />
-                  </div>
-                </div>
-                <div className={styles.branchRow}>
-                  <div className={styles.branchName + ' ' + styles.branchNameRelease}>release/<br/>1.0.0</div>
-                  <div className={styles.graphBranch + ' ' + styles.graphBranchRelease} style={{ width: '100px', left: '360px' }}>
-                    <div className={styles.graphCommit} style={{ left: '40px' }} />
-                    <div className={styles.graphCommit} style={{ left: '90px' }} />
-                  </div>
-                </div>
-              </div>
+              <ReactFlowGitGraph step={7} animationEnabled={animationEnabled} />
             </div>
           )}
         </div>
@@ -828,42 +658,7 @@ module.exports = {
             </div>
           ) : (
             <div className={styles.graphicView}>
-              <div className={styles.gitGraph}>
-                <div className={styles.branchRow}>
-                  <div className={styles.branchName + ' ' + styles.branchNameMain}>main/master<br/>(本番B面)</div>
-                  <div className={styles.graphBranch + ' ' + styles.graphBranchMain}>
-                    <div className={styles.graphCommit} style={{ left: '200px' }} />
-                    <div className={styles.graphCommit} style={{ left: '480px' }} />
-                    <div className={styles.graphTag} style={{ left: '495px' }}>v1.0.0</div>
-                  </div>
-                </div>
-                <div className={styles.graphArrow} 
-                     style={{ position: 'absolute', left: '460px', top: '16px', height: '100px', width: '2px', transform: 'rotate(45deg)', backgroundColor: '#f39c12', zIndex: 1 }}>
-                  <div className={styles.arrowHead} 
-                       style={{ position: 'absolute', top: '-5px', left: '-4px', borderWidth: '5px', borderStyle: 'solid', borderColor: '#f39c12 transparent transparent transparent', transform: 'rotate(0deg)' }} />
-                </div>
-                <div className={styles.branchRow}>
-                  <div className={styles.branchName + ' ' + styles.branchNameDevelop}>develop<br/>(開発A面)</div>
-                  <div className={styles.graphBranch + ' ' + styles.graphBranchDevelop}>
-                    <div className={styles.graphCommit} style={{ left: '200px' }} />
-                    <div className={styles.graphCommit} style={{ left: '280px' }} />
-                    <div className={styles.graphCommit} style={{ left: '380px' }} />
-                    <div className={styles.graphCommit} style={{ left: '520px' }} />
-                  </div>
-                </div>
-                <div className={styles.graphArrow} 
-                     style={{ position: 'absolute', left: '450px', top: '56px', height: '60px', width: '2px', transform: 'rotate(125deg)', backgroundColor: '#f39c12', zIndex: 1 }}>
-                  <div className={styles.arrowHead} 
-                       style={{ position: 'absolute', top: '-5px', left: '-4px', borderWidth: '5px', borderStyle: 'solid', borderColor: '#f39c12 transparent transparent transparent', transform: 'rotate(0deg)' }} />
-                </div>
-                <div className={styles.branchRow}>
-                  <div className={styles.branchName + ' ' + styles.branchNameRelease}>release/<br/>1.0.0</div>
-                  <div className={styles.graphBranch + ' ' + styles.graphBranchRelease} style={{ width: '100px', left: '360px' }}>
-                    <div className={styles.graphCommit} style={{ left: '40px' }} />
-                    <div className={styles.graphCommit} style={{ left: '90px' }} />
-                  </div>
-                </div>
-              </div>
+              <ReactFlowGitGraph step={8} animationEnabled={animationEnabled} />
             </div>
           )}
         </div>
@@ -949,38 +744,7 @@ module.exports = app;`}
             </div>
           ) : (
             <div className={styles.graphicView}>
-              <div className={styles.gitGraph}>
-                <div className={styles.branchRow}>
-                  <div className={styles.branchName + ' ' + styles.branchNameMain}>main/master<br/>(本番B面)</div>
-                  <div className={styles.graphBranch + ' ' + styles.graphBranchMain}>
-                    <div className={styles.graphCommit} style={{ left: '200px' }} />
-                    <div className={styles.graphCommit} style={{ left: '480px' }} />
-                    <div className={styles.graphTag} style={{ left: '495px' }}>v1.0.0</div>
-                    <div className={styles.graphCommitLabel} style={{ position: 'absolute', top: '-30px', left: '460px', fontSize: '10px', color: '#666' }}>releaseマージ</div>
-                  </div>
-                </div>
-                <div className={styles.graphArrow} 
-                     style={{ position: 'absolute', left: '490px', top: '16px', height: '40px', width: '2px', backgroundColor: '#9b59b6', zIndex: 1 }}>
-                  <div className={styles.arrowHead} 
-                       style={{ position: 'absolute', bottom: '-5px', left: '-4px', borderWidth: '5px', borderStyle: 'solid', borderColor: 'transparent transparent #9b59b6 transparent', transform: 'rotate(0deg)' }} />
-                </div>
-                <div className={styles.branchRow}>
-                  <div className={styles.branchName + ' ' + styles.branchNameDevelop}>develop<br/>(開発A面)</div>
-                  <div className={styles.graphBranch + ' ' + styles.graphBranchDevelop}>
-                    <div className={styles.graphCommit} style={{ left: '200px' }} />
-                    <div className={styles.graphCommit} style={{ left: '280px' }} />
-                    <div className={styles.graphCommit} style={{ left: '380px' }} />
-                    <div className={styles.graphCommit} style={{ left: '480px' }} />
-                  </div>
-                </div>
-                <div className={styles.branchRow}>
-                  <div className={styles.branchName + ' ' + styles.branchNameHotfix}>hotfix/<br/>1.0.1</div>
-                  <div className={styles.graphBranch + ' ' + styles.graphBranchHotfix} style={{ width: '40px', left: '480px' }}>
-                    <div className={styles.graphCommit} style={{ left: '30px' }} />
-                    <div className={styles.graphCommitLabel} style={{ position: 'absolute', top: '-30px', left: '10px', fontSize: '10px', color: '#666' }}>初期化例外処理追加</div>
-                  </div>
-                </div>
-              </div>
+              <ReactFlowGitGraph step={9} animationEnabled={animationEnabled} />
             </div>
           )}
         </div>
@@ -1061,46 +825,7 @@ module.exports = app;`}
             </div>
           ) : (
             <div className={styles.graphicView}>
-              <div className={styles.gitGraph}>
-                <div className={styles.branchRow}>
-                  <div className={styles.branchName + ' ' + styles.branchNameMain}>main/master<br/>(本番B面)</div>
-                  <div className={styles.graphBranch + ' ' + styles.graphBranchMain}>
-                    <div className={styles.graphCommit} style={{ left: '200px' }} />
-                    <div className={styles.graphCommit} style={{ left: '480px' }} />
-                    <div className={styles.graphCommit} style={{ left: '580px' }} />
-                    <div className={styles.graphTag} style={{ left: '595px' }}>v1.0.1</div>
-                    <div className={styles.graphCommitLabel} style={{ position: 'absolute', top: '-30px', left: '560px', fontSize: '10px', color: '#666' }}>hotfixマージ</div>
-                  </div>
-                </div>
-                <div className={styles.graphArrow} 
-                     style={{ position: 'absolute', left: '560px', top: '16px', height: '100px', width: '2px', transform: 'rotate(45deg)', backgroundColor: '#9b59b6', zIndex: 1 }}>
-                  <div className={styles.arrowHead} 
-                       style={{ position: 'absolute', top: '-5px', left: '-4px', borderWidth: '5px', borderStyle: 'solid', borderColor: '#9b59b6 transparent transparent transparent', transform: 'rotate(0deg)' }} />
-                </div>
-                <div className={styles.branchRow}>
-                  <div className={styles.branchName + ' ' + styles.branchNameDevelop}>develop<br/>(開発A面)</div>
-                  <div className={styles.graphBranch + ' ' + styles.graphBranchDevelop}>
-                    <div className={styles.graphCommit} style={{ left: '200px' }} />
-                    <div className={styles.graphCommit} style={{ left: '280px' }} />
-                    <div className={styles.graphCommit} style={{ left: '380px' }} />
-                    <div className={styles.graphCommit} style={{ left: '480px' }} />
-                    <div className={styles.graphCommit} style={{ left: '620px' }} />
-                    <div className={styles.graphCommitLabel} style={{ position: 'absolute', top: '-30px', left: '600px', fontSize: '10px', color: '#666' }}>hotfixマージ</div>
-                  </div>
-                </div>
-                <div className={styles.graphArrow} 
-                     style={{ position: 'absolute', left: '600px', top: '56px', height: '60px', width: '2px', transform: 'rotate(125deg)', backgroundColor: '#9b59b6', zIndex: 1 }}>
-                  <div className={styles.arrowHead} 
-                       style={{ position: 'absolute', top: '-5px', left: '-4px', borderWidth: '5px', borderStyle: 'solid', borderColor: '#9b59b6 transparent transparent transparent', transform: 'rotate(0deg)' }} />
-                </div>
-                <div className={styles.branchRow}>
-                  <div className={styles.branchName + ' ' + styles.branchNameHotfix}>hotfix/<br/>1.0.1</div>
-                  <div className={styles.graphBranch + ' ' + styles.graphBranchHotfix} style={{ width: '110px', left: '480px' }}>
-                    <div className={styles.graphCommit} style={{ left: '100px' }} />
-                    <div className={styles.graphCommitLabel} style={{ position: 'absolute', top: '-30px', left: '80px', fontSize: '10px', color: '#666' }}>緊急修正</div>
-                  </div>
-                </div>
-              </div>
+              <ReactFlowGitGraph step={10} animationEnabled={animationEnabled} />
             </div>
           )}
         </div>

--- a/container/claudecode/studyGIt/src/components/ReactFlowGitGraph.js
+++ b/container/claudecode/studyGIt/src/components/ReactFlowGitGraph.js
@@ -1,0 +1,721 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import ReactFlow, {
+  MiniMap,
+  Controls,
+  Background,
+  useNodesState,
+  useEdgesState,
+  addEdge,
+  Panel,
+} from 'reactflow';
+import 'reactflow/dist/style.css';
+
+// カスタムノードスタイル
+const nodeStyles = {
+  main: {
+    background: '#e74c3c',
+    color: 'white',
+    border: '1px solid #c0392b',
+    borderRadius: '4px',
+    padding: '10px',
+    width: '150px',
+  },
+  develop: {
+    background: '#3498db',
+    color: 'white',
+    border: '1px solid #2980b9',
+    borderRadius: '4px',
+    padding: '10px',
+    width: '150px',
+  },
+  feature: {
+    background: '#2ecc71',
+    color: 'white',
+    border: '1px solid #27ae60',
+    borderRadius: '4px',
+    padding: '10px',
+    width: '150px',
+  },
+  release: {
+    background: '#f39c12',
+    color: 'white',
+    border: '1px solid #e67e22',
+    borderRadius: '4px',
+    padding: '10px',
+    width: '150px',
+  },
+  hotfix: {
+    background: '#9b59b6',
+    color: 'white',
+    border: '1px solid #8e44ad',
+    borderRadius: '4px',
+    padding: '10px',
+    width: '150px',
+  },
+  tag: {
+    background: '#f1c40f',
+    color: 'black',
+    border: '1px solid #f39c12',
+    borderRadius: '50%',
+    padding: '5px',
+    width: '40px',
+    height: '40px',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    fontSize: '10px',
+    fontWeight: 'bold',
+  }
+};
+
+// エッジスタイル
+const edgeStyles = {
+  main: { stroke: '#e74c3c', strokeWidth: 2 },
+  develop: { stroke: '#3498db', strokeWidth: 2 },
+  feature: { stroke: '#2ecc71', strokeWidth: 2 },
+  release: { stroke: '#f39c12', strokeWidth: 2 },
+  hotfix: { stroke: '#9b59b6', strokeWidth: 2 },
+};
+
+// Git Flowのステップごとのノードとエッジ定義
+const gitFlowStepsData = {
+  1: {
+    title: "開発の開始 - developブランチ",
+    description: "プロジェクト開始時、最初にmainブランチからdevelopブランチを作成します。",
+    nodes: [
+      { 
+        id: 'main-1', 
+        type: 'default',
+        data: { label: 'main/master\n(本番B面)' }, 
+        position: { x: 250, y: 50 },
+        style: nodeStyles.main
+      },
+      { 
+        id: 'develop-1', 
+        type: 'default',
+        data: { label: 'develop\n(開発A面)' }, 
+        position: { x: 250, y: 150 },
+        style: nodeStyles.develop
+      }
+    ],
+    edges: [
+      {
+        id: 'main-develop',
+        source: 'main-1',
+        target: 'develop-1',
+        animated: true,
+        style: edgeStyles.develop,
+        type: 'smoothstep',
+        markerEnd: { type: 'arrowclosed' },
+      }
+    ]
+  },
+  2: {
+    title: "機能開発 - featureブランチ",
+    description: "新機能を開発する際は、developブランチからfeatureブランチを作成します。",
+    nodes: [
+      { 
+        id: 'main-1', 
+        type: 'default',
+        data: { label: 'main/master\n(本番B面)' }, 
+        position: { x: 250, y: 50 },
+        style: nodeStyles.main
+      },
+      { 
+        id: 'develop-1', 
+        type: 'default',
+        data: { label: 'develop\n(開発A面)' }, 
+        position: { x: 250, y: 150 },
+        style: nodeStyles.develop
+      },
+      { 
+        id: 'feature-login', 
+        type: 'default',
+        data: { label: 'feature/login-system' }, 
+        position: { x: 150, y: 250 },
+        style: nodeStyles.feature
+      }
+    ],
+    edges: [
+      {
+        id: 'main-develop',
+        source: 'main-1',
+        target: 'develop-1',
+        style: edgeStyles.develop,
+        type: 'smoothstep',
+        markerEnd: { type: 'arrowclosed' },
+      },
+      {
+        id: 'develop-feature',
+        source: 'develop-1',
+        target: 'feature-login',
+        animated: true,
+        style: edgeStyles.feature,
+        type: 'smoothstep',
+        markerEnd: { type: 'arrowclosed' },
+      }
+    ]
+  },
+  3: {
+    title: "featureブランチをdevelopにマージ",
+    description: "機能の開発とテストが完了したら、featureブランチをdevelopブランチにマージします。",
+    nodes: [
+      { 
+        id: 'main-1', 
+        type: 'default',
+        data: { label: 'main/master\n(本番B面)' }, 
+        position: { x: 250, y: 50 },
+        style: nodeStyles.main
+      },
+      { 
+        id: 'develop-1', 
+        type: 'default',
+        data: { label: 'develop\n(開発A面)' }, 
+        position: { x: 250, y: 150 },
+        style: nodeStyles.develop
+      },
+      { 
+        id: 'develop-2', 
+        type: 'default',
+        data: { label: 'develop\n(マージ後)' }, 
+        position: { x: 350, y: 150 },
+        style: nodeStyles.develop
+      },
+      { 
+        id: 'feature-login', 
+        type: 'default',
+        data: { label: 'feature/login-system' }, 
+        position: { x: 150, y: 250 },
+        style: nodeStyles.feature
+      }
+    ],
+    edges: [
+      {
+        id: 'main-develop',
+        source: 'main-1',
+        target: 'develop-1',
+        style: edgeStyles.develop,
+        type: 'smoothstep',
+        markerEnd: { type: 'arrowclosed' },
+      },
+      {
+        id: 'develop-feature',
+        source: 'develop-1',
+        target: 'feature-login',
+        style: edgeStyles.feature,
+        type: 'smoothstep',
+        markerEnd: { type: 'arrowclosed' },
+      },
+      {
+        id: 'develop-flow',
+        source: 'develop-1',
+        target: 'develop-2',
+        style: edgeStyles.develop,
+        type: 'smoothstep',
+      },
+      {
+        id: 'feature-develop',
+        source: 'feature-login',
+        target: 'develop-2',
+        animated: true,
+        style: edgeStyles.feature,
+        type: 'smoothstep',
+        markerEnd: { type: 'arrowclosed' },
+      }
+    ]
+  },
+  4: {
+    title: "別の機能開発 - 2つ目のfeatureブランチ",
+    description: "別の機能を並行して開発するために、新たなfeatureブランチを作成します。",
+    nodes: [
+      { 
+        id: 'main-1', 
+        type: 'default',
+        data: { label: 'main/master\n(本番B面)' }, 
+        position: { x: 250, y: 50 },
+        style: nodeStyles.main
+      },
+      { 
+        id: 'develop-2', 
+        type: 'default',
+        data: { label: 'develop' }, 
+        position: { x: 350, y: 150 },
+        style: nodeStyles.develop
+      },
+      { 
+        id: 'feature-profile', 
+        type: 'default',
+        data: { label: 'feature/user-profile' }, 
+        position: { x: 450, y: 250 },
+        style: nodeStyles.feature
+      }
+    ],
+    edges: [
+      {
+        id: 'main-develop',
+        source: 'main-1',
+        target: 'develop-2',
+        style: edgeStyles.develop,
+        type: 'smoothstep',
+        markerEnd: { type: 'arrowclosed' },
+      },
+      {
+        id: 'develop-feature2',
+        source: 'develop-2',
+        target: 'feature-profile',
+        animated: true,
+        style: edgeStyles.feature,
+        type: 'smoothstep',
+        markerEnd: { type: 'arrowclosed' },
+      }
+    ]
+  },
+  5: {
+    title: "2つ目のfeatureブランチをdevelopにマージ",
+    description: "ユーザープロファイル機能の開発とテストが完了したら、featureブランチをdevelopブランチにマージします。",
+    nodes: [
+      { 
+        id: 'main-1', 
+        type: 'default',
+        data: { label: 'main/master\n(本番B面)' }, 
+        position: { x: 250, y: 50 },
+        style: nodeStyles.main
+      },
+      { 
+        id: 'develop-2', 
+        type: 'default',
+        data: { label: 'develop' }, 
+        position: { x: 350, y: 150 },
+        style: nodeStyles.develop
+      },
+      { 
+        id: 'develop-3', 
+        type: 'default',
+        data: { label: 'develop\n(マージ後)' }, 
+        position: { x: 450, y: 150 },
+        style: nodeStyles.develop
+      },
+      { 
+        id: 'feature-profile', 
+        type: 'default',
+        data: { label: 'feature/user-profile' }, 
+        position: { x: 350, y: 250 },
+        style: nodeStyles.feature
+      }
+    ],
+    edges: [
+      {
+        id: 'main-develop',
+        source: 'main-1',
+        target: 'develop-2',
+        style: edgeStyles.develop,
+        type: 'smoothstep',
+        markerEnd: { type: 'arrowclosed' },
+      },
+      {
+        id: 'develop-feature2',
+        source: 'develop-2',
+        target: 'feature-profile',
+        style: edgeStyles.feature,
+        type: 'smoothstep',
+        markerEnd: { type: 'arrowclosed' },
+      },
+      {
+        id: 'develop-flow-2',
+        source: 'develop-2',
+        target: 'develop-3',
+        style: edgeStyles.develop,
+        type: 'smoothstep',
+      },
+      {
+        id: 'feature-develop-2',
+        source: 'feature-profile',
+        target: 'develop-3',
+        animated: true,
+        style: edgeStyles.feature,
+        type: 'smoothstep',
+        markerEnd: { type: 'arrowclosed' },
+      }
+    ]
+  },
+  6: {
+    title: "リリース準備 - releaseブランチの作成",
+    description: "機能開発が完了し、リリース準備を始める段階でreleaseブランチを作成します。",
+    nodes: [
+      { 
+        id: 'main-1', 
+        type: 'default',
+        data: { label: 'main/master\n(本番B面)' }, 
+        position: { x: 250, y: 50 },
+        style: nodeStyles.main
+      },
+      { 
+        id: 'develop-3', 
+        type: 'default',
+        data: { label: 'develop' }, 
+        position: { x: 450, y: 150 },
+        style: nodeStyles.develop
+      },
+      { 
+        id: 'release-1', 
+        type: 'default',
+        data: { label: 'release/1.0.0' }, 
+        position: { x: 550, y: 250 },
+        style: nodeStyles.release
+      }
+    ],
+    edges: [
+      {
+        id: 'main-develop',
+        source: 'main-1',
+        target: 'develop-3',
+        style: edgeStyles.develop,
+        type: 'smoothstep',
+        markerEnd: { type: 'arrowclosed' },
+      },
+      {
+        id: 'develop-release',
+        source: 'develop-3',
+        target: 'release-1',
+        animated: true,
+        style: edgeStyles.release,
+        type: 'smoothstep',
+        markerEnd: { type: 'arrowclosed' },
+      }
+    ]
+  },
+  7: {
+    title: "バグ修正 - releaseブランチでの修正",
+    description: "リリース準備中に発見されたバグは、releaseブランチ上で修正します。",
+    nodes: [
+      { 
+        id: 'main-1', 
+        type: 'default',
+        data: { label: 'main/master\n(本番B面)' }, 
+        position: { x: 250, y: 50 },
+        style: nodeStyles.main
+      },
+      { 
+        id: 'develop-3', 
+        type: 'default',
+        data: { label: 'develop' }, 
+        position: { x: 450, y: 150 },
+        style: nodeStyles.develop
+      },
+      { 
+        id: 'release-1', 
+        type: 'default',
+        data: { label: 'release/1.0.0' }, 
+        position: { x: 550, y: 250 },
+        style: nodeStyles.release
+      },
+      { 
+        id: 'release-2', 
+        type: 'default',
+        data: { label: 'release/1.0.0\n(バグ修正後)' }, 
+        position: { x: 650, y: 250 },
+        style: nodeStyles.release
+      }
+    ],
+    edges: [
+      {
+        id: 'main-develop',
+        source: 'main-1',
+        target: 'develop-3',
+        style: edgeStyles.develop,
+        type: 'smoothstep',
+        markerEnd: { type: 'arrowclosed' },
+      },
+      {
+        id: 'develop-release',
+        source: 'develop-3',
+        target: 'release-1',
+        style: edgeStyles.release,
+        type: 'smoothstep',
+        markerEnd: { type: 'arrowclosed' },
+      },
+      {
+        id: 'release-flow',
+        source: 'release-1',
+        target: 'release-2',
+        style: edgeStyles.release,
+        animated: true,
+        type: 'smoothstep',
+      }
+    ]
+  },
+  8: {
+    title: "リリース完了 - mainとdevelopへのマージ",
+    description: "リリース準備が完了したら、releaseブランチをmainとdevelopの両方にマージします。",
+    nodes: [
+      { 
+        id: 'main-1', 
+        type: 'default',
+        data: { label: 'main/master\n(本番B面)' }, 
+        position: { x: 250, y: 50 },
+        style: nodeStyles.main
+      },
+      { 
+        id: 'main-2', 
+        type: 'default',
+        data: { label: 'main/master\n(リリース後)' }, 
+        position: { x: 550, y: 50 },
+        style: nodeStyles.main
+      },
+      {
+        id: 'tag-v1',
+        type: 'default',
+        data: { label: 'v1.0.0' },
+        position: { x: 580, y: 20 },
+        style: nodeStyles.tag
+      },
+      { 
+        id: 'develop-3', 
+        type: 'default',
+        data: { label: 'develop' }, 
+        position: { x: 450, y: 150 },
+        style: nodeStyles.develop
+      },
+      { 
+        id: 'develop-4', 
+        type: 'default',
+        data: { label: 'develop\n(マージ後)' }, 
+        position: { x: 650, y: 150 },
+        style: nodeStyles.develop
+      },
+      { 
+        id: 'release-2', 
+        type: 'default',
+        data: { label: 'release/1.0.0' }, 
+        position: { x: 650, y: 250 },
+        style: nodeStyles.release
+      }
+    ],
+    edges: [
+      {
+        id: 'main-develop',
+        source: 'main-1',
+        target: 'develop-3',
+        style: edgeStyles.develop,
+        type: 'smoothstep',
+        markerEnd: { type: 'arrowclosed' },
+      },
+      {
+        id: 'main-flow',
+        source: 'main-1',
+        target: 'main-2',
+        style: edgeStyles.main,
+        type: 'smoothstep',
+      },
+      {
+        id: 'develop-flow',
+        source: 'develop-3',
+        target: 'develop-4',
+        style: edgeStyles.develop,
+        type: 'smoothstep',
+      },
+      {
+        id: 'release-main',
+        source: 'release-2',
+        target: 'main-2',
+        animated: true,
+        style: edgeStyles.release,
+        type: 'smoothstep',
+        markerEnd: { type: 'arrowclosed' },
+      },
+      {
+        id: 'release-develop',
+        source: 'release-2',
+        target: 'develop-4',
+        animated: true,
+        style: edgeStyles.release,
+        type: 'smoothstep',
+        markerEnd: { type: 'arrowclosed' },
+      }
+    ]
+  },
+  9: {
+    title: "本番環境のバグ修正 - hotfixブランチ",
+    description: "本番環境で重大なバグが発見された場合、mainブランチからhotfixブランチを作成して緊急修正します。",
+    nodes: [
+      { 
+        id: 'main-2', 
+        type: 'default',
+        data: { label: 'main/master\n(リリース済)' }, 
+        position: { x: 550, y: 50 },
+        style: nodeStyles.main
+      },
+      { 
+        id: 'develop-4', 
+        type: 'default',
+        data: { label: 'develop' }, 
+        position: { x: 650, y: 150 },
+        style: nodeStyles.develop
+      },
+      { 
+        id: 'hotfix-1', 
+        type: 'default',
+        data: { label: 'hotfix/1.0.1' }, 
+        position: { x: 750, y: 250 },
+        style: nodeStyles.hotfix
+      }
+    ],
+    edges: [
+      {
+        id: 'main-develop',
+        source: 'main-2',
+        target: 'develop-4',
+        style: edgeStyles.develop,
+        type: 'smoothstep',
+        markerEnd: { type: 'arrowclosed' },
+      },
+      {
+        id: 'main-hotfix',
+        source: 'main-2',
+        target: 'hotfix-1',
+        animated: true,
+        style: edgeStyles.hotfix,
+        type: 'smoothstep',
+        markerEnd: { type: 'arrowclosed' },
+      }
+    ]
+  },
+  10: {
+    title: "hotfixのマージ - mainとdevelopへ",
+    description: "hotfixが完了したら、mainとdevelopの両方にマージして、新しいタグを付けます。",
+    nodes: [
+      { 
+        id: 'main-2', 
+        type: 'default',
+        data: { label: 'main/master' }, 
+        position: { x: 550, y: 50 },
+        style: nodeStyles.main
+      },
+      { 
+        id: 'main-3', 
+        type: 'default',
+        data: { label: 'main/master\n(hotfix後)' }, 
+        position: { x: 750, y: 50 },
+        style: nodeStyles.main
+      },
+      {
+        id: 'tag-v2',
+        type: 'default',
+        data: { label: 'v1.0.1' },
+        position: { x: 780, y: 20 },
+        style: nodeStyles.tag
+      },
+      { 
+        id: 'develop-4', 
+        type: 'default',
+        data: { label: 'develop' }, 
+        position: { x: 650, y: 150 },
+        style: nodeStyles.develop
+      },
+      { 
+        id: 'develop-5', 
+        type: 'default',
+        data: { label: 'develop\n(hotfix後)' }, 
+        position: { x: 850, y: 150 },
+        style: nodeStyles.develop
+      },
+      { 
+        id: 'hotfix-1', 
+        type: 'default',
+        data: { label: 'hotfix/1.0.1' }, 
+        position: { x: 750, y: 250 },
+        style: nodeStyles.hotfix
+      }
+    ],
+    edges: [
+      {
+        id: 'main-flow',
+        source: 'main-2',
+        target: 'main-3',
+        style: edgeStyles.main,
+        type: 'smoothstep',
+      },
+      {
+        id: 'develop-flow',
+        source: 'develop-4',
+        target: 'develop-5',
+        style: edgeStyles.develop,
+        type: 'smoothstep',
+      },
+      {
+        id: 'hotfix-main',
+        source: 'hotfix-1',
+        target: 'main-3',
+        animated: true,
+        style: edgeStyles.hotfix,
+        type: 'smoothstep',
+        markerEnd: { type: 'arrowclosed' },
+      },
+      {
+        id: 'hotfix-develop',
+        source: 'hotfix-1',
+        target: 'develop-5',
+        animated: true,
+        style: edgeStyles.hotfix,
+        type: 'smoothstep',
+        markerEnd: { type: 'arrowclosed' },
+      }
+    ]
+  },
+};
+
+const ReactFlowGitGraph = ({ step = 1, animationEnabled = true }) => {
+  const currentStep = Math.min(Math.max(1, step), Object.keys(gitFlowStepsData).length);
+  const stepData = gitFlowStepsData[currentStep] || gitFlowStepsData[1];
+  
+  const [nodes, setNodes, onNodesChange] = useNodesState([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState([]);
+
+  // アニメーションの有無に応じてエッジを更新
+  useEffect(() => {
+    const updatedEdges = stepData.edges.map(edge => ({
+      ...edge,
+      animated: animationEnabled ? edge.animated : false
+    }));
+    setEdges(updatedEdges);
+    setNodes(stepData.nodes);
+  }, [stepData, animationEnabled, setEdges, setNodes]);
+
+  const onConnect = useCallback((params) => 
+    setEdges((eds) => addEdge({ ...params, type: 'smoothstep' }, eds)),
+  [setEdges]);
+
+  return (
+    <div style={{ height: 400, width: '100%', border: '1px solid #ddd', borderRadius: '8px' }}>
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        onConnect={onConnect}
+        fitView
+        attributionPosition="bottom-left"
+      >
+        <Controls />
+        <MiniMap 
+          nodeStrokeColor={(n) => {
+            if (n.style?.background) return n.style.background;
+            return '#eee';
+          }}
+          nodeColor={(n) => {
+            if (n.style?.background) return n.style.background;
+            return '#fff';
+          }}
+          nodeBorderRadius={2}
+        />
+        <Background color="#f8f8f8" gap={16} />
+        <Panel position="top-center" style={{ textAlign: 'center', padding: '10px' }}>
+          <h3 style={{ margin: 0 }}>{stepData.title}</h3>
+          <p style={{ marginBottom: 0 }}>{stepData.description}</p>
+        </Panel>
+      </ReactFlow>
+    </div>
+  );
+};
+
+export default ReactFlowGitGraph;


### PR DESCRIPTION
## Summary
- GitFlowGuideのグラフィカル表示部分をReactFlowコンポーネントを使用して実装
- ブランチやマージを示す矢印がブランチポイントやマージポイントの位置から正しく表示されるように修正
- 各ステップごとにReactFlowGitGraphコンポーネントを適切なstepパラメータで使用
- 図以外のコンテンツは一切変更していない

## Test plan
1. GitFlowGuideコンポーネントでグラフィカル表示を選択する
2. 各ステップでの図の表示を確認し、ブランチの矢印が正しい位置から出ていることを確認
3. マージ時の矢印が正しく表示されていることを確認
4. アニメーション表示のON/OFFが問題なく機能することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)