### PR TITLE
[fix]: Update Next.js to v12.3.4 to resolve module errors and improve documentation

### DIFF
--- a/container/claudecode/studyGIt/CLAUDE.md
+++ b/container/claudecode/studyGIt/CLAUDE.md
@@ -162,6 +162,7 @@ interface Commit {
 - styled-components
 - framer-motion
 - isomorphic-git (for Git operations simulation)
+- reactflow (for Git Flow diagram visualization)
 
 ### Volume Mounting
 
@@ -176,19 +177,42 @@ user: "root:root" # Set user to root:root to resolve permission issues
 
 The `z,U` flags are used for SELinux compatibility, and the root user setting ensures proper file permissions when mounting between host and container.
 
+### Container Configuration Notes
+
+The docker-compose.yml configuration includes important volume mounts:
+
+```yaml
+volumes:
+  - .:/app:z,U    # Mount local directory with SELinux flags
+  - /app/node_modules
+```
+
+This configuration ensures:
+1. The first mount maps the current directory to /app with SELinux permissions
+2. The second mount preserves the container's node_modules directory even when the host directory is mounted
+3. This setup prevents the container's installed dependencies from being overwritten
+
 ### Tutorials and Educational Content
 
 The application includes several tutorial components:
 
 1. **GitFlowGuide** (`src/components/GitFlowGuide.js`)
    - Teaches Git Flow branching strategy
-   - Includes both ASCII art and graphical visualization modes
+   - Includes both ASCII art and graphical visualization modes using ReactFlow
    - Shows step-by-step progression through the Git Flow workflow
    - Demonstrates branch operations, merges, and versioning
+   - Uses ReactFlowGitGraph component for interactive diagrams
 
 2. **ConflictGuide** (`src/components/ConflictGuide.js`)
    - Teaches conflict resolution workflows
    - Shows examples of conflict markers and resolution methods
+
+### Known Issues
+
+Next.js Module Resolution:
+- Some versions of Next.js may encounter a "Cannot find module '../server/require-hook'" error
+- If this occurs, consider using an alternative Next.js version (12.3.4 recommended)
+- This issue affects the container startup but not the core functionality once running
 
 ### Best Development Practices
 

--- a/container/claudecode/studyGIt/package.json
+++ b/container/claudecode/studyGIt/package.json
@@ -10,7 +10,7 @@
     "install:clean": "npm install --no-package-lock"
   },
   "dependencies": {
-    "next": "14.1.0",
+    "next": "12.3.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "isomorphic-git": "^1.24.5",
@@ -23,7 +23,7 @@
     "@types/react": "^18.2.46",
     "@types/react-dom": "^18.2.18",
     "eslint": "^8.56.0",
-    "eslint-config-next": "14.1.0",
+    "eslint-config-next": "12.3.4",
     "typescript": "^5.3.3"
   }
 }


### PR DESCRIPTION
## Summary
- Downgrade Next.js from 14.1.0 to 12.3.4 to fix require-hook module errors
- Update CLAUDE.md with container configuration details and known issues
- Document ReactFlow implementation for GitFlowGuide visualization

## Test plan
- Start container using podman-compose up --build
- Verify application starts without require-hook module errors
- Check GitFlowGuide displays correctly with ReactFlow visualization
- Review CLAUDE.md documentation updates for accuracy

🤖 Generated with [Claude Code](https://claude.ai/code)