### PR TITLE
[fix]: Add CSS and styling to Next.js 12.3.4 compatibility implementation

### DIFF
--- a/container/claudecode/studyGIt/src/pages/_app.js
+++ b/container/claudecode/studyGIt/src/pages/_app.js
@@ -1,0 +1,7 @@
+import '../app/globals.css'
+
+function MyApp({ Component, pageProps }) {
+  return <Component {...pageProps} />
+}
+
+export default MyApp

--- a/container/claudecode/studyGIt/src/pages/index.js
+++ b/container/claudecode/studyGIt/src/pages/index.js
@@ -1,113 +1,57 @@
 import React, { useState } from 'react';
 import Link from 'next/link';
+import styles from './index.module.css';
 
 export default function Home() {
   const [username, setUsername] = useState('');
   
   return (
-    <div style={{
-      display: 'flex',
-      flexDirection: 'column',
-      justifyContent: 'center',
-      alignItems: 'center',
-      height: '100vh',
-      fontFamily: 'Arial, sans-serif'
-    }}>
-      <h1 style={{ marginBottom: '1rem' }}>
-        Git<span style={{ color: '#0070f3' }}>Playground</span>
+    <div className={styles.main}>
+      <h1 className={styles.title}>
+        Git<span className={styles.highlight}>Playground</span>
       </h1>
       
-      <p style={{ marginBottom: '2rem', textAlign: 'center' }}>
+      <p className={styles.description}>
         チーム開発でのGit操作を楽しく学べるインタラクティブサイト
       </p>
 
-      <div style={{ 
-        padding: '1.5rem', 
-        border: '1px solid #eaeaea', 
-        borderRadius: '10px',
-        boxShadow: '0 4px 8px rgba(0, 0, 0, 0.1)',
-        width: '80%',
-        maxWidth: '500px'
-      }}>
+      <div className={styles.card}>
         <h2>Gitを学ぼう！</h2>
         <p>ファイルの追加、変更、削除などのGit操作を実際に体験できます。</p>
         <p>チーム開発のシミュレーションで他のメンバーとの協力作業も学べます。</p>
         
-        <div style={{ marginTop: '1.5rem', marginBottom: '1.5rem' }}>
-          <label htmlFor="username" style={{ display: 'block', marginBottom: '0.5rem' }}>あなたの名前:</label>
+        <div className={styles.inputGroup}>
+          <label htmlFor="username">あなたの名前:</label>
           <input 
             id="username"
             type="text" 
             value={username} 
             onChange={(e) => setUsername(e.target.value)}
             placeholder="名前を入力してください"
-            style={{
-              width: '100%',
-              padding: '0.5rem',
-              borderRadius: '4px',
-              border: '1px solid #ccc',
-              marginBottom: '1rem'
-            }}
           />
         </div>
         
         <Link href={`/playground${username ? `?username=${encodeURIComponent(username)}` : ''}`}>
-          <a style={{
-            backgroundColor: '#0070f3',
-            color: 'white',
-            padding: '0.75rem 1rem',
-            borderRadius: '4px',
-            textDecoration: 'none',
-            display: 'inline-block',
-            fontWeight: 'bold'
-          }}>
+          <a className={styles.button}>
             遊び方を学ぶ
           </a>
         </Link>
       </div>
 
-      <div style={{ 
-        display: 'flex', 
-        flexWrap: 'wrap',
-        justifyContent: 'center',
-        gap: '1rem',
-        marginTop: '2rem',
-        width: '80%',
-        maxWidth: '800px'
-      }}>
-        <div style={{ 
-          flex: '1 1 200px', 
-          padding: '1rem', 
-          border: '1px solid #eaeaea', 
-          borderRadius: '5px' 
-        }}>
+      <div className={styles.features}>
+        <div className={styles.featureCard}>
           <h3>ファイル操作</h3>
           <p>ファイルの追加、変更、削除操作を体験</p>
         </div>
-        <div style={{ 
-          flex: '1 1 200px', 
-          padding: '1rem', 
-          border: '1px solid #eaeaea', 
-          borderRadius: '5px' 
-        }}>
+        <div className={styles.featureCard}>
           <h3>コミット</h3>
           <p>変更をコミットして記録する方法を学ぶ</p>
         </div>
-        <div style={{ 
-          flex: '1 1 200px', 
-          padding: '1rem', 
-          border: '1px solid #eaeaea', 
-          borderRadius: '5px' 
-        }}>
+        <div className={styles.featureCard}>
           <h3>ブランチ</h3>
           <p>ブランチを使ったチーム開発のワークフロー</p>
         </div>
-        <div style={{ 
-          flex: '1 1 200px', 
-          padding: '1rem', 
-          border: '1px solid #eaeaea', 
-          borderRadius: '5px' 
-        }}>
+        <div className={styles.featureCard}>
           <h3>コンフリクト解決</h3>
           <p>競合の発生と解決方法を理解する</p>
         </div>

--- a/container/claudecode/studyGIt/src/pages/index.module.css
+++ b/container/claudecode/studyGIt/src/pages/index.module.css
@@ -1,0 +1,144 @@
+.main {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.title {
+  font-size: 3rem;
+  margin: 2rem 0;
+  text-align: center;
+  position: relative;
+  animation: float 3s ease-in-out infinite;
+}
+
+@keyframes float {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-10px); }
+}
+
+.highlight {
+  color: var(--primary);
+  position: relative;
+}
+
+.highlight::after {
+  content: '';
+  position: absolute;
+  bottom: -5px;
+  left: 0;
+  width: 100%;
+  height: 3px;
+  background-color: var(--accent);
+  border-radius: 2px;
+}
+
+.description {
+  font-size: 1.2rem;
+  text-align: center;
+  margin-bottom: 2rem;
+  max-width: 800px;
+}
+
+.card {
+  width: 100%;
+  max-width: 600px;
+  margin-bottom: 2rem;
+  text-align: center;
+  background-color: white;
+  border-radius: var(--border-radius);
+  padding: 1.5rem;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.card h2 {
+  margin-bottom: 1rem;
+  color: var(--primary);
+}
+
+.card p {
+  margin-bottom: 1rem;
+}
+
+.inputGroup {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 1.5rem 0;
+  width: 100%;
+}
+
+.inputGroup label {
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+}
+
+.inputGroup input {
+  padding: 0.5rem;
+  border-radius: var(--border-radius);
+  border: 2px solid #ddd;
+  width: 100%;
+  max-width: 300px;
+  font-size: 1rem;
+  transition: border-color 0.3s ease;
+}
+
+.inputGroup input:focus {
+  outline: none;
+  border-color: var(--primary);
+}
+
+.button {
+  margin-top: 1rem;
+  padding: 0.75rem 1.5rem;
+  font-size: 1.1rem;
+  background: linear-gradient(45deg, var(--primary), var(--accent));
+  color: white;
+  border-radius: var(--border-radius);
+  border: none;
+  cursor: pointer;
+  font-weight: bold;
+  text-decoration: none;
+  display: inline-block;
+  box-shadow: 0 4px 10px rgba(99, 102, 241, 0.2);
+}
+
+.button:hover {
+  box-shadow: 0 6px 12px rgba(99, 102, 241, 0.3);
+  transform: translateY(-1px);
+}
+
+.features {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  width: 100%;
+  margin-top: 2rem;
+}
+
+.featureCard {
+  background-color: white;
+  padding: 1.5rem;
+  border-radius: var(--border-radius);
+  text-align: center;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  transition: all 0.3s ease;
+  border-top: 4px solid var(--primary);
+}
+
+.featureCard:nth-child(2) {
+  border-top-color: var(--secondary);
+}
+
+.featureCard:nth-child(3) {
+  border-top-color: var(--accent);
+}
+
+.featureCard:nth-child(4) {
+  border-top-color: var(--success);
+}
+
+.featureCard h3 {
+  margin-bottom: 0.75rem;
+}

--- a/container/claudecode/studyGIt/src/pages/playground.js
+++ b/container/claudecode/studyGIt/src/pages/playground.js
@@ -7,6 +7,7 @@ import CommandTerminal from '../components/CommandTerminal';
 import TeamSimulator from '../components/TeamSimulator';
 import GitFlowGuide from '../components/GitFlowGuide';
 import TeamGitFlow from '../components/TeamGitFlow';
+import styles from './playground.module.css';
 
 export default function Playground() {
   const router = useRouter();
@@ -131,162 +132,79 @@ export default function Playground() {
     }
   };
   
-  // スタイル
-  const containerStyle = {
-    fontFamily: 'Arial, sans-serif',
-    maxWidth: '1200px',
-    margin: '0 auto',
-    padding: '1rem'
-  };
-  
-  const headerStyle = {
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: '1rem',
-    padding: '0.5rem',
-    backgroundColor: '#f0f0f0',
-    borderRadius: '8px'
-  };
-  
-  const tutorialStyle = {
-    backgroundColor: '#e6f7ff',
-    border: '1px solid #91d5ff',
-    borderRadius: '8px',
-    padding: '1rem',
-    marginBottom: '1rem'
-  };
-  
-  const progressStyle = {
-    display: 'flex',
-    justifyContent: 'center',
-    marginTop: '0.5rem'
-  };
-  
-  const progressDotStyle = {
-    width: '10px',
-    height: '10px',
-    borderRadius: '50%',
-    backgroundColor: '#d9d9d9',
-    margin: '0 5px'
-  };
-  
-  const activeDotStyle = {
-    ...progressDotStyle,
-    backgroundColor: '#1890ff'
-  };
-  
-  const tabsStyle = {
-    display: 'flex',
-    marginBottom: '1rem',
-    borderBottom: '1px solid #d9d9d9'
-  };
-  
-  const tabStyle = {
-    padding: '0.5rem 1rem',
-    cursor: 'pointer',
-    backgroundColor: '#f9f9f9',
-    border: '1px solid #d9d9d9',
-    borderBottom: 'none',
-    borderRadius: '4px 4px 0 0',
-    marginRight: '0.5rem'
-  };
-  
-  const activeTabStyle = {
-    ...tabStyle,
-    backgroundColor: '#fff',
-    borderBottom: '1px solid #fff',
-    marginBottom: '-1px',
-    fontWeight: 'bold'
-  };
-  
-  const contentStyle = {
-    border: '1px solid #d9d9d9',
-    borderRadius: '0 4px 4px 4px',
-    padding: '1rem',
-    minHeight: '500px'
-  };
-  
   if (!router.isReady) {
-    return <div style={containerStyle}>Loading...</div>;
+    return <div className={styles.playground}>Loading...</div>;
   }
   
   return (
-    <div style={containerStyle}>
-      <header style={headerStyle}>
+    <div className={styles.playground}>
+      <header className={styles.header}>
         <h1>GitPlayground</h1>
-        <div style={{ display: 'flex', alignItems: 'center' }}>
-          <span style={{ marginRight: '0.5rem' }}>👤</span>
+        <div className={styles.userInfo}>
+          <span className={styles.avatar}>👤</span>
           <span>{username || 'ユーザー'}</span>
         </div>
       </header>
       
       {tutorial.active && (
-        <div style={tutorialStyle}>
-          <div>
+        <div className={styles.tutorial}>
+          <div className={styles.tutorialContent}>
             <h3>チュートリアル</h3>
             <p>{tutorial.steps[tutorial.step]}</p>
             {tutorial.step === tutorial.steps.length - 1 && (
               <button 
                 onClick={() => setTutorial(prev => ({ ...prev, active: false }))}
-                style={{
-                  backgroundColor: '#1890ff',
-                  color: 'white',
-                  border: 'none',
-                  padding: '0.5rem 1rem',
-                  borderRadius: '4px',
-                  cursor: 'pointer'
-                }}
+                className={styles.tutorialButton}
               >
                 チュートリアルを終了
               </button>
             )}
           </div>
-          <div style={progressStyle}>
+          <div className={styles.progress}>
             {tutorial.steps.map((_, idx) => (
               <div 
                 key={idx} 
-                style={idx <= tutorial.step ? activeDotStyle : progressDotStyle}
+                className={`${styles.progressDot} ${idx <= tutorial.step ? styles.active : ''}`}
               />
             ))}
           </div>
         </div>
       )}
       
-      <div style={tabsStyle}>
+      <div className={styles.tabs}>
         <button 
-          style={activeTab === 'files' ? activeTabStyle : tabStyle}
+          className={`${styles.tab} ${activeTab === 'files' ? styles.active : ''}`}
           onClick={() => handleTabChange('files')}
         >
           ファイル操作
         </button>
         <button 
-          style={activeTab === 'commit' ? activeTabStyle : tabStyle}
+          className={`${styles.tab} ${activeTab === 'commit' ? styles.active : ''}`}
           onClick={() => handleTabChange('commit')}
         >
           コミット
         </button>
         <button 
-          style={activeTab === 'team' ? activeTabStyle : tabStyle}
+          className={`${styles.tab} ${activeTab === 'team' ? styles.active : ''}`}
           onClick={() => handleTabChange('team')}
         >
           チーム
         </button>
         <button 
-          style={activeTab === 'visualize' ? activeTabStyle : tabStyle}
+          className={`${styles.tab} ${activeTab === 'visualize' ? styles.active : ''}`}
           onClick={() => handleTabChange('visualize')}
         >
           可視化
         </button>
         <button 
-          style={activeTab === 'gitflow' ? activeTabStyle : tabStyle}
+          className={`${styles.tab} ${activeTab === 'gitflow' ? styles.active : ''}`}
           onClick={() => handleTabChange('gitflow')}
         >
           Git Flow
         </button>
       </div>
       
-      <div style={contentStyle}>
+      <div className={styles.content}>
         {activeTab === 'files' && (
           <FileExplorer 
             files={repository.files}
@@ -319,31 +237,16 @@ export default function Playground() {
         )}
         
         {activeTab === 'gitflow' && (
-          <div>
-            <div style={{ marginBottom: '1rem' }}>
+          <div className={styles.gitFlowSelector}>
+            <div className={styles.viewOptions}>
               <button 
-                style={{
-                  padding: '0.5rem 1rem',
-                  backgroundColor: gitFlowView === 'standard' ? '#1890ff' : '#f0f0f0',
-                  color: gitFlowView === 'standard' ? 'white' : 'black',
-                  border: '1px solid #d9d9d9',
-                  borderRadius: '4px',
-                  marginRight: '0.5rem',
-                  cursor: 'pointer'
-                }}
+                className={`${styles.viewOption} ${gitFlowView === 'standard' ? styles.active : ''}`}
                 onClick={() => setGitFlowView('standard')}
               >
                 標準 Git Flow
               </button>
               <button 
-                style={{
-                  padding: '0.5rem 1rem',
-                  backgroundColor: gitFlowView === 'team' ? '#1890ff' : '#f0f0f0',
-                  color: gitFlowView === 'team' ? 'white' : 'black',
-                  border: '1px solid #d9d9d9',
-                  borderRadius: '4px',
-                  cursor: 'pointer'
-                }}
+                className={`${styles.viewOption} ${gitFlowView === 'team' ? styles.active : ''}`}
                 onClick={() => setGitFlowView('team')}
               >
                 チーム Git Flow

--- a/container/claudecode/studyGIt/src/pages/playground.module.css
+++ b/container/claudecode/studyGIt/src/pages/playground.module.css
@@ -1,0 +1,195 @@
+.playground {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  min-height: 80vh;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+  background-color: white;
+  padding: 1rem;
+  border-radius: var(--border-radius);
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+.header h1 {
+  color: var(--primary);
+  margin: 0;
+}
+
+.userInfo {
+  display: flex;
+  align-items: center;
+  background-color: white;
+  padding: 0.5rem 1rem;
+  border-radius: 2rem;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+.avatar {
+  margin-right: 0.5rem;
+  font-size: 1.2rem;
+}
+
+.tutorial {
+  background: linear-gradient(to right, var(--primary), var(--accent));
+  color: white;
+  border-radius: var(--border-radius);
+  padding: 1.5rem;
+  margin-bottom: 2rem;
+  box-shadow: 0 4px 10px rgba(99, 102, 241, 0.3);
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0% { box-shadow: 0 4px 10px rgba(99, 102, 241, 0.3); }
+  50% { box-shadow: 0 4px 20px rgba(99, 102, 241, 0.5); }
+  100% { box-shadow: 0 4px 10px rgba(99, 102, 241, 0.3); }
+}
+
+.tutorialContent {
+  margin-bottom: 1rem;
+}
+
+.tutorialContent h3 {
+  margin-bottom: 0.5rem;
+}
+
+.tutorialButton {
+  margin-top: 1rem;
+  background-color: white;
+  color: var(--primary);
+  padding: 0.5rem 1rem;
+  border-radius: var(--border-radius);
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+}
+
+.progress {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.progressDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background-color: rgba(255, 255, 255, 0.3);
+  transition: all 0.3s ease;
+}
+
+.progressDot.active {
+  background-color: white;
+  transform: scale(1.2);
+}
+
+.tabs {
+  display: flex;
+  margin-bottom: 1rem;
+  overflow-x: auto;
+  gap: 0.5rem;
+}
+
+.tab {
+  padding: 0.75rem 1.5rem;
+  background-color: white;
+  color: var(--foreground);
+  border-radius: var(--border-radius);
+  font-weight: 600;
+  transition: all 0.3s ease;
+  border: none;
+  cursor: pointer;
+}
+
+.tab:hover {
+  background-color: #f0f0f0;
+  transform: translateY(-1px);
+}
+
+.tab.active {
+  background-color: var(--primary);
+  color: white;
+}
+
+.content {
+  flex: 1;
+  background-color: white;
+  border-radius: var(--border-radius);
+  padding: 1.5rem;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  min-height: 500px;
+}
+
+.gitFlowContainer {
+  padding: 20px;
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  margin-bottom: 20px;
+}
+
+.gitFlowContainer h2 {
+  color: #3498db;
+  border-bottom: 2px solid #f0f0f0;
+  padding-bottom: 10px;
+  margin-bottom: 20px;
+}
+
+.gitFlowContainer ul {
+  list-style-type: none;
+  padding-left: 20px;
+}
+
+.gitFlowContainer li {
+  padding: 8px 0;
+  border-bottom: 1px solid #f0f0f0;
+  margin-bottom: 8px;
+}
+
+.gitFlowContainer strong {
+  font-weight: bold;
+  color: #333;
+  margin-right: 8px;
+}
+
+/* TeamGitFlow component integration styles */
+.gitFlowSelector {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.viewOptions {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 1.5rem;
+  gap: 1rem;
+}
+
+.viewOption {
+  padding: 0.75rem 1.5rem;
+  background-color: #f0f0f0;
+  border-radius: var(--border-radius);
+  font-weight: 600;
+  transition: all 0.3s ease;
+  min-width: 150px;
+  text-align: center;
+  border: none;
+  cursor: pointer;
+}
+
+.viewOption:hover {
+  background-color: #e0e0e0;
+  transform: translateY(-2px);
+}
+
+.viewOption.active {
+  background-color: var(--primary);
+  color: white;
+}


### PR DESCRIPTION
## Summary
- Added CSS modules for index and playground pages to match original design
- Created _app.js to properly import global CSS styles 
- Fixed white/unstyled appearance in pages implementation
- Applied class-based styling to replace inline styles

## Test plan
1. Run `podman-compose up -d` to start the container
2. Navigate to http://localhost:3000 in your browser  
3. Verify that the GitPlayground homepage loads with proper styling and colors
4. Enter a username and click "遊び方を学ぶ" to navigate to the playground page
5. Confirm all tabs have proper styling and color scheme
6. Test podman system prune to ensure it works with a clean cache

🤖 Generated with [Claude Code](https://claude.ai/code)