### PR TITLE
[Docker] トップページからの学習コンテンツアクセス改善

### DIFF
--- a/container/claudecode/studyGIt/src/app/docker-learning/page.module.css
+++ b/container/claudecode/studyGIt/src/app/docker-learning/page.module.css
@@ -1,0 +1,391 @@
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 20px;
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
+    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 30px;
+}
+
+.title {
+  font-size: 2.5rem;
+  color: #333;
+  margin: 0;
+}
+
+.highlight {
+  color: #0070f3;
+}
+
+.backLink {
+  padding: 8px 16px;
+  background-color: #eaeaea;
+  color: #333;
+  border-radius: 4px;
+  text-decoration: none;
+  font-size: 0.9rem;
+  transition: background-color 0.3s;
+}
+
+.backLink:hover {
+  background-color: #ddd;
+}
+
+.navigation {
+  margin-bottom: 20px;
+}
+
+.tabList {
+  display: flex;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  border-bottom: 1px solid #ddd;
+}
+
+.tab {
+  padding: 10px 20px;
+  cursor: pointer;
+  border-radius: 4px 4px 0 0;
+  margin-right: 5px;
+  transition: all 0.3s;
+}
+
+.tab:hover {
+  background-color: #f5f5f5;
+}
+
+.tab.active {
+  background-color: #0070f3;
+  color: white;
+  font-weight: bold;
+}
+
+.content {
+  background: #fff;
+  border-radius: 0 0 8px 8px;
+  padding: 20px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  min-height: 400px;
+}
+
+.tabContent h2 {
+  color: #0070f3;
+  margin-top: 0;
+}
+
+.visualContainer {
+  display: flex;
+  gap: 40px;
+  margin: 30px 0;
+}
+
+.containerVisual {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.containerBox {
+  width: 200px;
+  border: 2px solid #0070f3;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.appLayer, .libLayer, .binLayer {
+  padding: 15px;
+  text-align: center;
+}
+
+.appLayer {
+  background-color: #c2e0ff;
+}
+
+.libLayer {
+  background-color: #d1f7c4;
+}
+
+.binLayer {
+  background-color: #ffe8c2;
+}
+
+.description {
+  flex: 2;
+}
+
+.keyPoints {
+  margin-top: 30px;
+  padding: 20px;
+  background-color: #f5f9ff;
+  border-radius: 8px;
+}
+
+.keyPoints h3 {
+  color: #0070f3;
+  margin-top: 0;
+}
+
+.keyPoints ul {
+  margin: 0;
+  padding-left: 20px;
+}
+
+.keyPoints li {
+  margin-bottom: 10px;
+}
+
+/* VS Virtual Machine styles */
+.comparisonContainer {
+  display: flex;
+  gap: 30px;
+  margin: 30px 0;
+}
+
+.comparisonItem {
+  flex: 1;
+  border: 1px solid #ddd;
+  padding: 20px;
+  border-radius: 8px;
+  text-align: center;
+}
+
+.comparisonItem h3 {
+  color: #0070f3;
+  margin-top: 0;
+}
+
+.containerStack, .vmStack {
+  display: flex;
+  flex-direction: column;
+  margin: 20px 0;
+}
+
+.containerStack > div,
+.vmStack > div {
+  padding: 10px;
+  margin-bottom: 2px;
+  text-align: center;
+}
+
+.app {
+  background-color: #c2e0ff;
+}
+
+.containerEngine {
+  background-color: #d1f7c4;
+}
+
+.os {
+  background-color: #ffe8c2;
+}
+
+.hardware {
+  background-color: #ffd2d2;
+}
+
+.vmBox {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid #0070f3;
+  margin-bottom: 10px;
+}
+
+.guestOs {
+  background-color: #ffc2eb;
+}
+
+.hypervisor {
+  background-color: #e2c2ff;
+}
+
+.featureList {
+  list-style: none;
+  padding: 0;
+  text-align: left;
+}
+
+.featureList li {
+  margin-bottom: 8px;
+  position: relative;
+  padding-left: 20px;
+}
+
+.featureList li:before {
+  content: "✓";
+  position: absolute;
+  left: 0;
+  color: #0070f3;
+}
+
+.keyDifference {
+  background-color: #f5f9ff;
+  padding: 15px;
+  border-radius: 8px;
+  margin-top: 20px;
+}
+
+/* Host and container relationship */
+.relationshipDiagram {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 30px;
+  margin: 30px 0;
+}
+
+.hostSystem, .containerSystem {
+  flex: 1;
+  border: 1px solid #0070f3;
+  border-radius: 8px;
+  padding: 20px;
+}
+
+.hostSystem h3, .containerSystem h3 {
+  text-align: center;
+  margin-top: 0;
+  color: #0070f3;
+}
+
+.hostComponents {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.hostKernel {
+  background-color: #ffc2eb;
+  padding: 15px;
+  text-align: center;
+}
+
+.hostResources {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.hostResources div {
+  background-color: #e2c2ff;
+  padding: 10px;
+  text-align: center;
+}
+
+.arrows {
+  font-size: 2rem;
+  color: #0070f3;
+}
+
+.multipleContainers {
+  display: flex;
+  gap: 15px;
+}
+
+.singleContainer {
+  flex: 1;
+  border: 1px dashed #0070f3;
+  padding: 10px;
+}
+
+.singleContainer div {
+  padding: 8px;
+  margin-bottom: 8px;
+  text-align: center;
+}
+
+.singleContainer div:nth-child(1) {
+  background-color: #c2e0ff;
+}
+
+.singleContainer div:nth-child(2) {
+  background-color: #d1f7c4;
+}
+
+.singleContainer div:nth-child(3) {
+  background-color: #ffe8c2;
+}
+
+.singleContainer div:nth-child(4) {
+  background-color: #ffd2d2;
+}
+
+.relationshipExplanation {
+  margin-top: 30px;
+}
+
+.relationshipExplanation h3 {
+  color: #0070f3;
+}
+
+.relationshipExplanation ul {
+  padding-left: 20px;
+}
+
+.relationshipExplanation li {
+  margin-bottom: 15px;
+}
+
+/* Interactive Demo */
+.comingSoon {
+  text-align: center;
+  font-size: 1.2rem;
+  color: #666;
+  margin: 30px 0;
+}
+
+.mockTerminal {
+  margin: 30px 0;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+  font-family: monospace;
+}
+
+.terminalHeader {
+  background-color: #333;
+  color: white;
+  padding: 10px 15px;
+  display: flex;
+  justify-content: center;
+}
+
+.terminalBody {
+  background-color: #1e1e1e;
+  color: #f0f0f0;
+  padding: 15px;
+  white-space: pre-wrap;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.terminalBody p {
+  margin: 5px 0;
+}
+
+.terminalOutput {
+  color: #a0a0a0;
+}
+
+/* Mini button for Docker feature card */
+.miniButton {
+  background-color: #0070f3;
+  color: white;
+  border: none;
+  padding: 6px 12px;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  cursor: pointer;
+  margin-top: 8px;
+  transition: background-color 0.3s;
+}
+
+.miniButton:hover {
+  background-color: #0051bb;
+}

--- a/container/claudecode/studyGIt/src/app/docker-learning/page.tsx
+++ b/container/claudecode/studyGIt/src/app/docker-learning/page.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { useState } from 'react';
+import Link from 'next/link';
+import styles from './page.module.css';
+
+export default function DockerLearning() {
+  const [activeTab, setActiveTab] = useState('what-is-container');
+  
+  return (
+    <div className={styles.container}>
+      <header className={styles.header}>
+        <h1 className={styles.title}>
+          Docker<span className={styles.highlight}>学習</span>
+        </h1>
+        <Link href="/" className={styles.backLink}>
+          トップページへ戻る
+        </Link>
+      </header>
+
+      <nav className={styles.navigation}>
+        <ul className={styles.tabList}>
+          <li 
+            className={`${styles.tab} ${activeTab === 'what-is-container' ? styles.active : ''}`}
+            onClick={() => setActiveTab('what-is-container')}
+          >
+            コンテナとは何か？
+          </li>
+          <li 
+            className={`${styles.tab} ${activeTab === 'vs-virtual-machine' ? styles.active : ''}`}
+            onClick={() => setActiveTab('vs-virtual-machine')}
+          >
+            仮想マシンとの違い
+          </li>
+          <li 
+            className={`${styles.tab} ${activeTab === 'host-container-relation' ? styles.active : ''}`}
+            onClick={() => setActiveTab('host-container-relation')}
+          >
+            ホストとの関係
+          </li>
+          <li 
+            className={`${styles.tab} ${activeTab === 'interactive-demo' ? styles.active : ''}`}
+            onClick={() => setActiveTab('interactive-demo')}
+          >
+            インタラクティブデモ
+          </li>
+        </ul>
+      </nav>
+
+      <main className={styles.content}>
+        {activeTab === 'what-is-container' && (
+          <div className={styles.tabContent}>
+            <h2>コンテナとは何か？</h2>
+            <div className={styles.visualContainer}>
+              <div className={styles.containerVisual}>
+                <div className={styles.containerBox}>
+                  <div className={styles.appLayer}>アプリケーション</div>
+                  <div className={styles.libLayer}>ライブラリ／依存関係</div>
+                  <div className={styles.binLayer}>バイナリ／ツール</div>
+                </div>
+              </div>
+              <div className={styles.description}>
+                <p>
+                  <strong>コンテナ</strong>は、アプリケーションとその依存関係を一緒にパッケージ化した軽量な実行環境です。
+                </p>
+                <p>
+                  アプリケーションコードだけでなく、ライブラリ、設定ファイル、バイナリなど、
+                  アプリケーションの実行に必要なすべてのものを含んでいます。
+                </p>
+                <p>
+                  コンテナは<strong>分離された空間</strong>で動作するため、どの環境でも同じように動作します。
+                  「私のマシンでは動作するのに...」という問題を解消します。
+                </p>
+              </div>
+            </div>
+            <div className={styles.keyPoints}>
+              <h3>コンテナの主な特徴</h3>
+              <ul>
+                <li><strong>軽量</strong>: 仮想マシンと比べてリソース消費が少ない</li>
+                <li><strong>ポータブル</strong>: どの環境でも同じように実行できる</li>
+                <li><strong>迅速</strong>: 数秒で起動可能</li>
+                <li><strong>分離</strong>: 他のコンテナやホストシステムに影響を与えない</li>
+                <li><strong>スケーラブル</strong>: 必要に応じて複数のインスタンスを簡単に作成</li>
+              </ul>
+            </div>
+          </div>
+        )}
+
+        {activeTab === 'vs-virtual-machine' && (
+          <div className={styles.tabContent}>
+            <h2>仮想マシンとの違い</h2>
+            <div className={styles.comparisonContainer}>
+              <div className={styles.comparisonItem}>
+                <h3>コンテナ</h3>
+                <div className={styles.containerStack}>
+                  <div className={styles.app}>App A</div>
+                  <div className={styles.app}>App B</div>
+                  <div className={styles.app}>App C</div>
+                  <div className={styles.containerEngine}>コンテナエンジン</div>
+                  <div className={styles.os}>ホストOS</div>
+                  <div className={styles.hardware}>ハードウェア</div>
+                </div>
+                <ul className={styles.featureList}>
+                  <li>OSカーネルを共有</li>
+                  <li>軽量（数MB〜数百MB）</li>
+                  <li>起動時間: 数秒</li>
+                  <li>アプリケーション実行に必要な部分のみ</li>
+                </ul>
+              </div>
+              <div className={styles.comparisonItem}>
+                <h3>仮想マシン</h3>
+                <div className={styles.vmStack}>
+                  <div className={styles.vmBox}>
+                    <div className={styles.app}>App A</div>
+                    <div className={styles.guestOs}>ゲストOS</div>
+                  </div>
+                  <div className={styles.vmBox}>
+                    <div className={styles.app}>App B</div>
+                    <div className={styles.guestOs}>ゲストOS</div>
+                  </div>
+                  <div className={styles.vmBox}>
+                    <div className={styles.app}>App C</div>
+                    <div className={styles.guestOs}>ゲストOS</div>
+                  </div>
+                  <div className={styles.hypervisor}>ハイパーバイザー</div>
+                  <div className={styles.os}>ホストOS</div>
+                  <div className={styles.hardware}>ハードウェア</div>
+                </div>
+                <ul className={styles.featureList}>
+                  <li>完全なOS（カーネル含む）</li>
+                  <li>重量級（数GB）</li>
+                  <li>起動時間: 数分</li>
+                  <li>完全な分離と互換性</li>
+                </ul>
+              </div>
+            </div>
+            <div className={styles.keyDifference}>
+              <p>
+                <strong>主な違い</strong>: コンテナは<em>アプリケーションの実行環境</em>を分離するのに対し、
+                仮想マシンは<em>ハードウェアレベルからOSまで</em>を仮想化します。
+                コンテナはホストOSのカーネルを共有するため軽量で高速ですが、
+                仮想マシンは独自のOSを持ち完全に分離されています。
+              </p>
+            </div>
+          </div>
+        )}
+
+        {activeTab === 'host-container-relation' && (
+          <div className={styles.tabContent}>
+            <h2>ホストとコンテナの関係</h2>
+            <div className={styles.relationshipDiagram}>
+              <div className={styles.hostSystem}>
+                <h3>ホストシステム</h3>
+                <div className={styles.hostComponents}>
+                  <div className={styles.hostKernel}>Linuxカーネル</div>
+                  <div className={styles.hostResources}>
+                    <div>CPU</div>
+                    <div>メモリ</div>
+                    <div>ストレージ</div>
+                    <div>ネットワーク</div>
+                  </div>
+                </div>
+              </div>
+              <div className={styles.arrows}>↔</div>
+              <div className={styles.containerSystem}>
+                <h3>コンテナ</h3>
+                <div className={styles.multipleContainers}>
+                  <div className={styles.singleContainer}>
+                    <div>アプリA</div>
+                    <div>ライブラリ</div>
+                    <div>名前空間</div>
+                    <div>cgroups</div>
+                  </div>
+                  <div className={styles.singleContainer}>
+                    <div>アプリB</div>
+                    <div>ライブラリ</div>
+                    <div>名前空間</div>
+                    <div>cgroups</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div className={styles.relationshipExplanation}>
+              <h3>ホストとコンテナの関係性</h3>
+              <ul>
+                <li>
+                  <strong>カーネル共有</strong>: コンテナはホストOSのカーネルを共有しますが、
+                  それぞれのコンテナはファイルシステム、プロセス、ネットワークが分離されています。
+                </li>
+                <li>
+                  <strong>名前空間 (Namespaces)</strong>: Linuxの名前空間機能により、
+                  コンテナ内のプロセスが独自の分離された環境を持ちます。
+                </li>
+                <li>
+                  <strong>コントロールグループ (cgroups)</strong>: コンテナが使用できる
+                  CPU、メモリ、ディスクI/Oなどのリソースを制限できます。
+                </li>
+                <li>
+                  <strong>ポート転送</strong>: コンテナの内部ポートをホストの特定のポートに
+                  マッピングすることで、外部からアクセス可能になります。
+                </li>
+                <li>
+                  <strong>ボリュームマウント</strong>: ホストのディレクトリをコンテナ内に
+                  マウントして、データの永続化や共有が可能です。
+                </li>
+              </ul>
+            </div>
+          </div>
+        )}
+
+        {activeTab === 'interactive-demo' && (
+          <div className={styles.tabContent}>
+            <h2>インタラクティブデモ</h2>
+            <p className={styles.comingSoon}>
+              インタラクティブなDocker学習エクスペリエンスを準備中です。
+              近日公開予定ですので、もうしばらくお待ちください。
+            </p>
+            <div className={styles.mockTerminal}>
+              <div className={styles.terminalHeader}>
+                <span>Docker ターミナル</span>
+              </div>
+              <div className={styles.terminalBody}>
+                <p>$ docker run -d -p 80:80 nginx</p>
+                <p>a7f3s9d8f7a9sd87f9as8d7f9asd8f7</p>
+                <p>$ docker ps</p>
+                <p className={styles.terminalOutput}>
+                CONTAINER ID   IMAGE   COMMAND                  CREATED         STATUS         PORTS                NAMES<br/>
+                a7f3s9d8       nginx   "/docker-entrypoint.…"   5 seconds ago   Up 4 seconds   0.0.0.0:80->80/tcp   inspiring_edison
+                </p>
+                <p>$ docker exec -it a7f3s9d8 /bin/bash</p>
+                <p>root@a7f3s9d8:/# ls</p>
+                <p>bin  boot  dev  etc  home  lib  media  mnt  opt  proc  root  run  sbin  srv  sys  tmp  usr  var</p>
+                <p>root@a7f3s9d8:/# exit</p>
+                <p>$ _</p>
+              </div>
+            </div>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/container/claudecode/studyGIt/src/app/page.tsx
+++ b/container/claudecode/studyGIt/src/app/page.tsx
@@ -57,6 +57,13 @@ export default function Home() {
           <h3>コンフリクト解決</h3>
           <p>競合の発生と解決方法を理解する</p>
         </div>
+        <div className={styles.featureCard}>
+          <h3>Docker入門</h3>
+          <p>コンテナの基本概念を視覚的に学ぶ</p>
+          <Link href="/docker-learning">
+            <button className={styles.miniButton}>学習する</button>
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/container/claudecode/studyGIt/src/pages/docker-learning.js
+++ b/container/claudecode/studyGIt/src/pages/docker-learning.js
@@ -1,0 +1,242 @@
+import React, { useState } from 'react';
+import Link from 'next/link';
+import styles from './docker-learning.module.css';
+
+export default function DockerLearning() {
+  const [activeTab, setActiveTab] = useState('what-is-container');
+  
+  return (
+    <div className={styles.container}>
+      <header className={styles.header}>
+        <h1 className={styles.title}>
+          Docker<span className={styles.highlight}>学習</span>
+        </h1>
+        <Link href="/">
+          <a className={styles.backLink}>
+            トップページへ戻る
+          </a>
+        </Link>
+      </header>
+
+      <nav className={styles.navigation}>
+        <ul className={styles.tabList}>
+          <li 
+            className={`${styles.tab} ${activeTab === 'what-is-container' ? styles.active : ''}`}
+            onClick={() => setActiveTab('what-is-container')}
+          >
+            コンテナとは何か？
+          </li>
+          <li 
+            className={`${styles.tab} ${activeTab === 'vs-virtual-machine' ? styles.active : ''}`}
+            onClick={() => setActiveTab('vs-virtual-machine')}
+          >
+            仮想マシンとの違い
+          </li>
+          <li 
+            className={`${styles.tab} ${activeTab === 'host-container-relation' ? styles.active : ''}`}
+            onClick={() => setActiveTab('host-container-relation')}
+          >
+            ホストとの関係
+          </li>
+          <li 
+            className={`${styles.tab} ${activeTab === 'interactive-demo' ? styles.active : ''}`}
+            onClick={() => setActiveTab('interactive-demo')}
+          >
+            インタラクティブデモ
+          </li>
+        </ul>
+      </nav>
+
+      <main className={styles.content}>
+        {activeTab === 'what-is-container' && (
+          <div className={styles.tabContent}>
+            <h2>コンテナとは何か？</h2>
+            <div className={styles.visualContainer}>
+              <div className={styles.containerVisual}>
+                <div className={styles.containerBox}>
+                  <div className={styles.appLayer}>アプリケーション</div>
+                  <div className={styles.libLayer}>ライブラリ／依存関係</div>
+                  <div className={styles.binLayer}>バイナリ／ツール</div>
+                </div>
+              </div>
+              <div className={styles.description}>
+                <p>
+                  <strong>コンテナ</strong>は、アプリケーションとその依存関係を一緒にパッケージ化した軽量な実行環境です。
+                </p>
+                <p>
+                  アプリケーションコードだけでなく、ライブラリ、設定ファイル、バイナリなど、
+                  アプリケーションの実行に必要なすべてのものを含んでいます。
+                </p>
+                <p>
+                  コンテナは<strong>分離された空間</strong>で動作するため、どの環境でも同じように動作します。
+                  「私のマシンでは動作するのに...」という問題を解消します。
+                </p>
+              </div>
+            </div>
+            <div className={styles.keyPoints}>
+              <h3>コンテナの主な特徴</h3>
+              <ul>
+                <li><strong>軽量</strong>: 仮想マシンと比べてリソース消費が少ない</li>
+                <li><strong>ポータブル</strong>: どの環境でも同じように実行できる</li>
+                <li><strong>迅速</strong>: 数秒で起動可能</li>
+                <li><strong>分離</strong>: 他のコンテナやホストシステムに影響を与えない</li>
+                <li><strong>スケーラブル</strong>: 必要に応じて複数のインスタンスを簡単に作成</li>
+              </ul>
+            </div>
+          </div>
+        )}
+
+        {activeTab === 'vs-virtual-machine' && (
+          <div className={styles.tabContent}>
+            <h2>仮想マシンとの違い</h2>
+            <div className={styles.comparisonContainer}>
+              <div className={styles.comparisonItem}>
+                <h3>コンテナ</h3>
+                <div className={styles.containerStack}>
+                  <div className={styles.app}>App A</div>
+                  <div className={styles.app}>App B</div>
+                  <div className={styles.app}>App C</div>
+                  <div className={styles.containerEngine}>コンテナエンジン</div>
+                  <div className={styles.os}>ホストOS</div>
+                  <div className={styles.hardware}>ハードウェア</div>
+                </div>
+                <ul className={styles.featureList}>
+                  <li>OSカーネルを共有</li>
+                  <li>軽量（数MB〜数百MB）</li>
+                  <li>起動時間: 数秒</li>
+                  <li>アプリケーション実行に必要な部分のみ</li>
+                </ul>
+              </div>
+              <div className={styles.comparisonItem}>
+                <h3>仮想マシン</h3>
+                <div className={styles.vmStack}>
+                  <div className={styles.vmBox}>
+                    <div className={styles.app}>App A</div>
+                    <div className={styles.guestOs}>ゲストOS</div>
+                  </div>
+                  <div className={styles.vmBox}>
+                    <div className={styles.app}>App B</div>
+                    <div className={styles.guestOs}>ゲストOS</div>
+                  </div>
+                  <div className={styles.vmBox}>
+                    <div className={styles.app}>App C</div>
+                    <div className={styles.guestOs}>ゲストOS</div>
+                  </div>
+                  <div className={styles.hypervisor}>ハイパーバイザー</div>
+                  <div className={styles.os}>ホストOS</div>
+                  <div className={styles.hardware}>ハードウェア</div>
+                </div>
+                <ul className={styles.featureList}>
+                  <li>完全なOS（カーネル含む）</li>
+                  <li>重量級（数GB）</li>
+                  <li>起動時間: 数分</li>
+                  <li>完全な分離と互換性</li>
+                </ul>
+              </div>
+            </div>
+            <div className={styles.keyDifference}>
+              <p>
+                <strong>主な違い</strong>: コンテナは<em>アプリケーションの実行環境</em>を分離するのに対し、
+                仮想マシンは<em>ハードウェアレベルからOSまで</em>を仮想化します。
+                コンテナはホストOSのカーネルを共有するため軽量で高速ですが、
+                仮想マシンは独自のOSを持ち完全に分離されています。
+              </p>
+            </div>
+          </div>
+        )}
+
+        {activeTab === 'host-container-relation' && (
+          <div className={styles.tabContent}>
+            <h2>ホストとコンテナの関係</h2>
+            <div className={styles.relationshipDiagram}>
+              <div className={styles.hostSystem}>
+                <h3>ホストシステム</h3>
+                <div className={styles.hostComponents}>
+                  <div className={styles.hostKernel}>Linuxカーネル</div>
+                  <div className={styles.hostResources}>
+                    <div>CPU</div>
+                    <div>メモリ</div>
+                    <div>ストレージ</div>
+                    <div>ネットワーク</div>
+                  </div>
+                </div>
+              </div>
+              <div className={styles.arrows}>↔</div>
+              <div className={styles.containerSystem}>
+                <h3>コンテナ</h3>
+                <div className={styles.multipleContainers}>
+                  <div className={styles.singleContainer}>
+                    <div>アプリA</div>
+                    <div>ライブラリ</div>
+                    <div>名前空間</div>
+                    <div>cgroups</div>
+                  </div>
+                  <div className={styles.singleContainer}>
+                    <div>アプリB</div>
+                    <div>ライブラリ</div>
+                    <div>名前空間</div>
+                    <div>cgroups</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div className={styles.relationshipExplanation}>
+              <h3>ホストとコンテナの関係性</h3>
+              <ul>
+                <li>
+                  <strong>カーネル共有</strong>: コンテナはホストOSのカーネルを共有しますが、
+                  それぞれのコンテナはファイルシステム、プロセス、ネットワークが分離されています。
+                </li>
+                <li>
+                  <strong>名前空間 (Namespaces)</strong>: Linuxの名前空間機能により、
+                  コンテナ内のプロセスが独自の分離された環境を持ちます。
+                </li>
+                <li>
+                  <strong>コントロールグループ (cgroups)</strong>: コンテナが使用できる
+                  CPU、メモリ、ディスクI/Oなどのリソースを制限できます。
+                </li>
+                <li>
+                  <strong>ポート転送</strong>: コンテナの内部ポートをホストの特定のポートに
+                  マッピングすることで、外部からアクセス可能になります。
+                </li>
+                <li>
+                  <strong>ボリュームマウント</strong>: ホストのディレクトリをコンテナ内に
+                  マウントして、データの永続化や共有が可能です。
+                </li>
+              </ul>
+            </div>
+          </div>
+        )}
+
+        {activeTab === 'interactive-demo' && (
+          <div className={styles.tabContent}>
+            <h2>インタラクティブデモ</h2>
+            <p className={styles.comingSoon}>
+              インタラクティブなDocker学習エクスペリエンスを準備中です。
+              近日公開予定ですので、もうしばらくお待ちください。
+            </p>
+            <div className={styles.mockTerminal}>
+              <div className={styles.terminalHeader}>
+                <span>Docker ターミナル</span>
+              </div>
+              <div className={styles.terminalBody}>
+                <p>$ docker run -d -p 80:80 nginx</p>
+                <p>a7f3s9d8f7a9sd87f9as8d7f9asd8f7</p>
+                <p>$ docker ps</p>
+                <p className={styles.terminalOutput}>
+                CONTAINER ID   IMAGE   COMMAND                  CREATED         STATUS         PORTS                NAMES<br/>
+                a7f3s9d8       nginx   "/docker-entrypoint.…"   5 seconds ago   Up 4 seconds   0.0.0.0:80->80/tcp   inspiring_edison
+                </p>
+                <p>$ docker exec -it a7f3s9d8 /bin/bash</p>
+                <p>root@a7f3s9d8:/# ls</p>
+                <p>bin  boot  dev  etc  home  lib  media  mnt  opt  proc  root  run  sbin  srv  sys  tmp  usr  var</p>
+                <p>root@a7f3s9d8:/# exit</p>
+                <p>$ _</p>
+              </div>
+            </div>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/container/claudecode/studyGIt/src/pages/docker-learning.module.css
+++ b/container/claudecode/studyGIt/src/pages/docker-learning.module.css
@@ -1,0 +1,391 @@
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 20px;
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
+    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 30px;
+}
+
+.title {
+  font-size: 2.5rem;
+  color: #333;
+  margin: 0;
+}
+
+.highlight {
+  color: #0070f3;
+}
+
+.backLink {
+  padding: 8px 16px;
+  background-color: #eaeaea;
+  color: #333;
+  border-radius: 4px;
+  text-decoration: none;
+  font-size: 0.9rem;
+  transition: background-color 0.3s;
+}
+
+.backLink:hover {
+  background-color: #ddd;
+}
+
+.navigation {
+  margin-bottom: 20px;
+}
+
+.tabList {
+  display: flex;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  border-bottom: 1px solid #ddd;
+}
+
+.tab {
+  padding: 10px 20px;
+  cursor: pointer;
+  border-radius: 4px 4px 0 0;
+  margin-right: 5px;
+  transition: all 0.3s;
+}
+
+.tab:hover {
+  background-color: #f5f5f5;
+}
+
+.tab.active {
+  background-color: #0070f3;
+  color: white;
+  font-weight: bold;
+}
+
+.content {
+  background: #fff;
+  border-radius: 0 0 8px 8px;
+  padding: 20px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  min-height: 400px;
+}
+
+.tabContent h2 {
+  color: #0070f3;
+  margin-top: 0;
+}
+
+.visualContainer {
+  display: flex;
+  gap: 40px;
+  margin: 30px 0;
+}
+
+.containerVisual {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.containerBox {
+  width: 200px;
+  border: 2px solid #0070f3;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.appLayer, .libLayer, .binLayer {
+  padding: 15px;
+  text-align: center;
+}
+
+.appLayer {
+  background-color: #c2e0ff;
+}
+
+.libLayer {
+  background-color: #d1f7c4;
+}
+
+.binLayer {
+  background-color: #ffe8c2;
+}
+
+.description {
+  flex: 2;
+}
+
+.keyPoints {
+  margin-top: 30px;
+  padding: 20px;
+  background-color: #f5f9ff;
+  border-radius: 8px;
+}
+
+.keyPoints h3 {
+  color: #0070f3;
+  margin-top: 0;
+}
+
+.keyPoints ul {
+  margin: 0;
+  padding-left: 20px;
+}
+
+.keyPoints li {
+  margin-bottom: 10px;
+}
+
+/* VS Virtual Machine styles */
+.comparisonContainer {
+  display: flex;
+  gap: 30px;
+  margin: 30px 0;
+}
+
+.comparisonItem {
+  flex: 1;
+  border: 1px solid #ddd;
+  padding: 20px;
+  border-radius: 8px;
+  text-align: center;
+}
+
+.comparisonItem h3 {
+  color: #0070f3;
+  margin-top: 0;
+}
+
+.containerStack, .vmStack {
+  display: flex;
+  flex-direction: column;
+  margin: 20px 0;
+}
+
+.containerStack > div,
+.vmStack > div {
+  padding: 10px;
+  margin-bottom: 2px;
+  text-align: center;
+}
+
+.app {
+  background-color: #c2e0ff;
+}
+
+.containerEngine {
+  background-color: #d1f7c4;
+}
+
+.os {
+  background-color: #ffe8c2;
+}
+
+.hardware {
+  background-color: #ffd2d2;
+}
+
+.vmBox {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid #0070f3;
+  margin-bottom: 10px;
+}
+
+.guestOs {
+  background-color: #ffc2eb;
+}
+
+.hypervisor {
+  background-color: #e2c2ff;
+}
+
+.featureList {
+  list-style: none;
+  padding: 0;
+  text-align: left;
+}
+
+.featureList li {
+  margin-bottom: 8px;
+  position: relative;
+  padding-left: 20px;
+}
+
+.featureList li:before {
+  content: "✓";
+  position: absolute;
+  left: 0;
+  color: #0070f3;
+}
+
+.keyDifference {
+  background-color: #f5f9ff;
+  padding: 15px;
+  border-radius: 8px;
+  margin-top: 20px;
+}
+
+/* Host and container relationship */
+.relationshipDiagram {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 30px;
+  margin: 30px 0;
+}
+
+.hostSystem, .containerSystem {
+  flex: 1;
+  border: 1px solid #0070f3;
+  border-radius: 8px;
+  padding: 20px;
+}
+
+.hostSystem h3, .containerSystem h3 {
+  text-align: center;
+  margin-top: 0;
+  color: #0070f3;
+}
+
+.hostComponents {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.hostKernel {
+  background-color: #ffc2eb;
+  padding: 15px;
+  text-align: center;
+}
+
+.hostResources {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.hostResources div {
+  background-color: #e2c2ff;
+  padding: 10px;
+  text-align: center;
+}
+
+.arrows {
+  font-size: 2rem;
+  color: #0070f3;
+}
+
+.multipleContainers {
+  display: flex;
+  gap: 15px;
+}
+
+.singleContainer {
+  flex: 1;
+  border: 1px dashed #0070f3;
+  padding: 10px;
+}
+
+.singleContainer div {
+  padding: 8px;
+  margin-bottom: 8px;
+  text-align: center;
+}
+
+.singleContainer div:nth-child(1) {
+  background-color: #c2e0ff;
+}
+
+.singleContainer div:nth-child(2) {
+  background-color: #d1f7c4;
+}
+
+.singleContainer div:nth-child(3) {
+  background-color: #ffe8c2;
+}
+
+.singleContainer div:nth-child(4) {
+  background-color: #ffd2d2;
+}
+
+.relationshipExplanation {
+  margin-top: 30px;
+}
+
+.relationshipExplanation h3 {
+  color: #0070f3;
+}
+
+.relationshipExplanation ul {
+  padding-left: 20px;
+}
+
+.relationshipExplanation li {
+  margin-bottom: 15px;
+}
+
+/* Interactive Demo */
+.comingSoon {
+  text-align: center;
+  font-size: 1.2rem;
+  color: #666;
+  margin: 30px 0;
+}
+
+.mockTerminal {
+  margin: 30px 0;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+  font-family: monospace;
+}
+
+.terminalHeader {
+  background-color: #333;
+  color: white;
+  padding: 10px 15px;
+  display: flex;
+  justify-content: center;
+}
+
+.terminalBody {
+  background-color: #1e1e1e;
+  color: #f0f0f0;
+  padding: 15px;
+  white-space: pre-wrap;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.terminalBody p {
+  margin: 5px 0;
+}
+
+.terminalOutput {
+  color: #a0a0a0;
+}
+
+/* Mini button for Docker feature card */
+.miniButton {
+  background-color: #0070f3;
+  color: white;
+  border: none;
+  padding: 6px 12px;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  cursor: pointer;
+  margin-top: 8px;
+  transition: background-color 0.3s;
+}
+
+.miniButton:hover {
+  background-color: #0051bb;
+}

--- a/container/claudecode/studyGIt/src/pages/index.js
+++ b/container/claudecode/studyGIt/src/pages/index.js
@@ -55,6 +55,13 @@ export default function Home() {
           <h3>コンフリクト解決</h3>
           <p>競合の発生と解決方法を理解する</p>
         </div>
+        <div className={styles.featureCard}>
+          <h3>Docker入門</h3>
+          <p>コンテナの基本概念を視覚的に学ぶ</p>
+          <Link href="/docker-learning">
+            <a className={styles.miniButton}>学習する</a>
+          </Link>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## 概要
Docker学習コンテンツへのアクセス問題を解決し、トップページから直接アクセスできるように改善しました。

## 変更内容
- **トップページの機能拡張**: 
  - トップページの機能カードセクションに「Docker入門」カードを追加
  - App Router (page.tsx)とPages Router (index.js)の両方に実装

- **Docker学習コンテンツページの作成**:
  - App Router向け: `/src/app/docker-learning/page.tsx` 
  - Pages Router向け: `/src/pages/docker-learning.js`
  - 両方のルーターで同一の学習体験を提供

- **コンテンツの実装**:
  - タブ式インターフェースでコンテナの基本概念を解説
  - 視覚的な図とダイアグラムによる直感的な説明
  - 以下の3つの主要テーマを実装
    1. コンテナとは何か
    2. 仮想マシンとの違い
    3. ホストとの関係

## 関連Issue
Closes #48

## テスト方法
1. トップページにアクセスし、「Docker入門」機能カードが表示されることを確認
2. 「学習する」ボタンをクリックして、Docker学習ページに移動できることを確認
3. タブを切り替えて、各コンテンツが正しく表示されることを確認

## スクリーンショット
（実際の環境ではスクリーンショットを添付）