### PR TITLE
[Docker] コア学習コンポーネントの追加

### DIFF
--- a/container/claudecode/studyGIt/src/components/DefaultDocker.js
+++ b/container/claudecode/studyGIt/src/components/DefaultDocker.js
@@ -1,0 +1,68 @@
+// DefaultDocker.js
+// Dockerコンテナのサンプルデータ
+
+const DEFAULT_DOCKER_STATE = {
+  containers: [
+    {
+      id: 'abc123def456',
+      name: 'git-playground',
+      image: 'git-playground:latest',
+      status: 'running',
+      ports: [
+        {
+          host: '3000',
+          container: '3000'
+        }
+      ],
+      volumes: [
+        {
+          host: '.',
+          container: '/app'
+        },
+        {
+          host: '/app/node_modules',
+          container: '/app/node_modules'
+        }
+      ],
+      networks: ['git-playground_default']
+    },
+    {
+      id: '789ghi101112',
+      name: 'postgres-db',
+      image: 'postgres:13',
+      status: 'running',
+      ports: [
+        {
+          host: '5432',
+          container: '5432'
+        }
+      ],
+      volumes: [
+        {
+          host: 'postgres-data',
+          container: '/var/lib/postgresql/data'
+        }
+      ],
+      networks: ['git-playground_default']
+    },
+    {
+      id: '131415jkl',
+      name: 'redis-cache',
+      image: 'redis:alpine',
+      status: 'exited',
+      ports: [
+        {
+          host: '6379',
+          container: '6379'
+        }
+      ],
+      volumes: [],
+      networks: ['git-playground_default']
+    }
+  ],
+  networks: ['git-playground_default', 'bridge'],
+  images: ['git-playground:latest', 'postgres:13', 'redis:alpine', 'node:16'],
+  volumes: ['postgres-data', 'node_modules']
+};
+
+export default DEFAULT_DOCKER_STATE;

--- a/container/claudecode/studyGIt/src/components/DockerChallenges.tsx
+++ b/container/claudecode/studyGIt/src/components/DockerChallenges.tsx
@@ -1,0 +1,326 @@
+"use client";
+
+import React, { useState, useEffect } from 'react';
+import { motion } from 'framer-motion';
+import styles from './DockerGuide.module.css';
+import { DifficultyLevel } from './DockerSimulator';
+
+export interface Challenge {
+  id: string;
+  title: string;
+  description: string;
+  difficultyLevel: DifficultyLevel;
+  hint: string;
+  solution: string;
+  expectedCommand: string | RegExp;
+  isCompleted: boolean;
+  testFn?: (cmd: string) => boolean;
+}
+
+export interface DockerChallengesProps {
+  currentLevel: DifficultyLevel;
+  onChallengeComplete: (challengeId: string) => void;
+  onCommandExecute?: (command: string) => void;
+}
+
+const DockerChallenges: React.FC<DockerChallengesProps> = ({ 
+  currentLevel, 
+  onChallengeComplete,
+  onCommandExecute
+}) => {
+  const [challenges, setChallenges] = useState<Challenge[]>([
+    // レベル1: 初心者向けチャレンジ
+    {
+      id: 'basic-1',
+      title: 'コンテナリスト表示',
+      description: '実行中のコンテナの一覧を表示するコマンドを実行してください。',
+      difficultyLevel: DifficultyLevel.BEGINNER,
+      hint: 'docker psコマンドを使います。',
+      solution: 'docker ps',
+      expectedCommand: 'docker ps',
+      isCompleted: false
+    },
+    {
+      id: 'basic-2',
+      title: 'イメージ一覧表示',
+      description: '利用可能なDockerイメージの一覧を表示するコマンドを実行してください。',
+      difficultyLevel: DifficultyLevel.BEGINNER,
+      hint: 'docker imagesコマンドを使います。',
+      solution: 'docker images',
+      expectedCommand: 'docker images',
+      isCompleted: false
+    },
+    {
+      id: 'basic-3',
+      title: 'Nginxコンテナの実行',
+      description: 'Nginxイメージを使用して、バックグラウンドで実行され、ホストの8080ポートをコンテナの80ポートにマッピングするコンテナを起動してください。',
+      difficultyLevel: DifficultyLevel.BEGINNER,
+      hint: 'docker runコマンドを使い、-dフラグでバックグラウンド実行、-pフラグでポートマッピングを指定します。',
+      solution: 'docker run -d -p 8080:80 nginx',
+      expectedCommand: /docker run .*-d.*-p.*8080:80.*nginx|docker run .*-p.*8080:80.*-d.*nginx/,
+      isCompleted: false
+    },
+
+    // レベル2: 基本的なチャレンジ
+    {
+      id: 'intermediate-1',
+      title: 'イメージのプル',
+      description: 'Redis最新バージョンのイメージをプルしてください。',
+      difficultyLevel: DifficultyLevel.BASIC,
+      hint: 'docker pullコマンドを使います。',
+      solution: 'docker pull redis',
+      expectedCommand: /docker pull redis(:latest)?/,
+      isCompleted: false
+    },
+    {
+      id: 'intermediate-2',
+      title: 'コンテナのログ確認',
+      description: 'my-containerという名前のコンテナのログを表示してください。',
+      difficultyLevel: DifficultyLevel.BASIC,
+      hint: 'docker logsコマンドを使います。',
+      solution: 'docker logs my-container',
+      expectedCommand: 'docker logs my-container',
+      isCompleted: false
+    },
+    {
+      id: 'intermediate-3',
+      title: 'コンテナの削除',
+      description: '停止中のコンテナmy-containerを削除してください。',
+      difficultyLevel: DifficultyLevel.BASIC,
+      hint: 'docker rmコマンドを使います。',
+      solution: 'docker rm my-container',
+      expectedCommand: 'docker rm my-container',
+      isCompleted: false
+    },
+
+    // レベル3: 中級者向けチャレンジ
+    {
+      id: 'advanced-1',
+      title: 'ネットワーク作成',
+      description: 'my-networkという名前の新しいDockerネットワークを作成してください。',
+      difficultyLevel: DifficultyLevel.INTERMEDIATE,
+      hint: 'docker network createコマンドを使います。',
+      solution: 'docker network create my-network',
+      expectedCommand: 'docker network create my-network',
+      isCompleted: false
+    },
+    {
+      id: 'advanced-2',
+      title: 'ボリューム作成',
+      description: 'my-dataという名前の新しいDockerボリュームを作成してください。',
+      difficultyLevel: DifficultyLevel.INTERMEDIATE,
+      hint: 'docker volume createコマンドを使います。',
+      solution: 'docker volume create my-data',
+      expectedCommand: 'docker volume create my-data',
+      isCompleted: false
+    },
+    {
+      id: 'advanced-3',
+      title: 'コンテナ内でのコマンド実行',
+      description: 'my-containerという名前のコンテナ内でlsコマンドを実行してください。',
+      difficultyLevel: DifficultyLevel.INTERMEDIATE,
+      hint: 'docker execコマンドを使います。',
+      solution: 'docker exec my-container ls',
+      expectedCommand: /docker exec my-container ls.*/,
+      isCompleted: false
+    },
+
+    // レベル4: 上級者向けチャレンジ
+    {
+      id: 'expert-1',
+      title: 'Docker Compose起動',
+      description: 'Docker Composeを使用して、バックグラウンドでサービスを起動してください。',
+      difficultyLevel: DifficultyLevel.ADVANCED,
+      hint: 'docker compose upコマンドと-dフラグを使います。',
+      solution: 'docker compose up -d',
+      expectedCommand: /docker compose up -d|docker-compose up -d/,
+      isCompleted: false
+    },
+    {
+      id: 'expert-2',
+      title: 'Docker Compose停止',
+      description: 'Docker Composeを使用して、すべてのサービスを停止し、コンテナとネットワークを削除してください。',
+      difficultyLevel: DifficultyLevel.ADVANCED,
+      hint: 'docker compose downコマンドを使います。',
+      solution: 'docker compose down',
+      expectedCommand: /docker compose down|docker-compose down/,
+      isCompleted: false
+    }
+  ]);
+
+  // ユーザーのレベルに応じたチャレンジのみ表示
+  const availableChallenges = challenges.filter(
+    challenge => challenge.difficultyLevel <= currentLevel
+  );
+
+  // チャレンジの進捗状況を計算
+  const completedCount = availableChallenges.filter(c => c.isCompleted).length;
+  const progressPercentage = availableChallenges.length > 0 
+    ? (completedCount / availableChallenges.length) * 100
+    : 0;
+
+  // コマンド検証のハンドラー
+  const checkCommand = (command: string, challenge: Challenge) => {
+    let isCorrect = false;
+    
+    if (challenge.testFn) {
+      // カスタムテスト関数がある場合はそれを使用
+      isCorrect = challenge.testFn(command);
+    } else if (challenge.expectedCommand instanceof RegExp) {
+      // 正規表現の場合
+      isCorrect = challenge.expectedCommand.test(command);
+    } else {
+      // 文字列の完全一致
+      isCorrect = command === challenge.expectedCommand;
+    }
+    
+    if (isCorrect && !challenge.isCompleted) {
+      // チャレンジ成功を記録
+      const updatedChallenges = challenges.map(c => 
+        c.id === challenge.id ? { ...c, isCompleted: true } : c
+      );
+      setChallenges(updatedChallenges);
+      
+      // 親コンポーネントに通知
+      onChallengeComplete(challenge.id);
+    }
+    
+    return isCorrect;
+  };
+
+  // 初期状態をLocalStorageから復元
+  useEffect(() => {
+    const savedChallenges = localStorage.getItem('docker-challenges');
+    if (savedChallenges) {
+      try {
+        const parsedChallenges = JSON.parse(savedChallenges);
+        setChallenges(prevChallenges => 
+          prevChallenges.map(c => {
+            const savedChallenge = parsedChallenges.find((saved: Challenge) => saved.id === c.id);
+            return savedChallenge ? { ...c, isCompleted: savedChallenge.isCompleted } : c;
+          })
+        );
+      } catch (error) {
+        console.error('Failed to parse saved challenges', error);
+      }
+    }
+  }, []);
+
+  // チャレンジの状態変更をLocalStorageに保存
+  useEffect(() => {
+    localStorage.setItem('docker-challenges', JSON.stringify(challenges.map(c => ({
+      id: c.id,
+      isCompleted: c.isCompleted
+    }))));
+  }, [challenges]);
+
+  // コマンド実行をDockerTerminalに伝播
+  const handleTryCommand = (command: string) => {
+    if (onCommandExecute) {
+      onCommandExecute(command);
+    }
+  };
+
+  return (
+    <motion.div 
+      className={styles.dockerChallenges}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.5 }}
+    >
+      <h2>Dockerチャレンジ</h2>
+      
+      <div className={styles.challengeProgress}>
+        <div className={styles.progressText}>
+          進捗状況: {completedCount} / {availableChallenges.length} チャレンジ完了
+        </div>
+        <div className={styles.progressBar}>
+          <div 
+            className={styles.progressFill}
+            style={{ width: `${progressPercentage}%` }}
+          />
+        </div>
+      </div>
+      
+      <div className={styles.challengeList}>
+        {availableChallenges.map((challenge) => (
+          <motion.div 
+            key={challenge.id}
+            className={`${styles.challengeCard} ${challenge.isCompleted ? styles.completed : ''}`}
+            whileHover={{ scale: 1.02 }}
+            transition={{ duration: 0.2 }}
+          >
+            <div className={styles.challengeHeader}>
+              <h3>{challenge.title}</h3>
+              {challenge.isCompleted && (
+                <span className={styles.completedBadge}>
+                  ✓ 完了
+                </span>
+              )}
+            </div>
+            
+            <p className={styles.challengeDescription}>{challenge.description}</p>
+            
+            <div className={styles.challengeActions}>
+              <div className={styles.hintSection}>
+                <details>
+                  <summary>ヒントを見る</summary>
+                  <p className={styles.hint}>{challenge.hint}</p>
+                </details>
+              </div>
+              
+              <div className={styles.solutionSection}>
+                <details>
+                  <summary>解答を見る</summary>
+                  <div className={styles.solution}>
+                    <div className={styles.solutionCommand}>{challenge.solution}</div>
+                    <button 
+                      className={styles.tryButton}
+                      onClick={() => handleTryCommand(challenge.solution)}
+                    >
+                      試してみる
+                    </button>
+                  </div>
+                </details>
+              </div>
+            </div>
+            
+            <div className={styles.difficultyBadge}>
+              {getDifficultyLabel(challenge.difficultyLevel)}
+            </div>
+          </motion.div>
+        ))}
+      </div>
+      
+      {availableChallenges.length === 0 && (
+        <div className={styles.noChallenge}>
+          <p>現在のレベルで利用可能なチャレンジはありません。レベルアップするとチャレンジが解放されます。</p>
+        </div>
+      )}
+      
+      {currentLevel < DifficultyLevel.ADVANCED && (
+        <div className={styles.levelUpInfo}>
+          <p>「レベルアップ」ボタンをクリックすると、より高度なチャレンジが解放されます。</p>
+        </div>
+      )}
+    </motion.div>
+  );
+};
+
+// 難易度レベルのラベル取得
+function getDifficultyLabel(level: DifficultyLevel): string {
+  switch (level) {
+    case DifficultyLevel.BEGINNER:
+      return '初級';
+    case DifficultyLevel.BASIC:
+      return '基本';
+    case DifficultyLevel.INTERMEDIATE:
+      return '中級';
+    case DifficultyLevel.ADVANCED:
+      return '上級';
+    default:
+      return '不明';
+  }
+}
+
+export default DockerChallenges;

--- a/container/claudecode/studyGIt/src/components/DockerCommandInterpreter.ts
+++ b/container/claudecode/studyGIt/src/components/DockerCommandInterpreter.ts
@@ -1,0 +1,327 @@
+/**
+ * DockerCommandInterpreter.ts
+ * Docker コマンドの解釈と実行、および他コンポーネントとの連携を担当
+ */
+
+import { DockerSimulator, DockerState, DifficultyLevel, CommandResult } from './DockerSimulator';
+
+// Docker コマンド実行イベントの型定義
+export interface DockerCommandEvent {
+  command: string;         // 実行されたコマンド
+  result: CommandResult;   // 実行結果
+  previousState: DockerState; // 実行前のDocker状態
+  currentState: DockerState;  // 実行後のDocker状態
+  timestamp: number;       // イベント発生時刻
+}
+
+// 学習イベントの型定義
+export interface DockerLearningEvent {
+  topic: string;           // 学習したトピック
+  command: string;         // 関連するコマンド
+  level: DifficultyLevel;  // 学習レベル
+  completed: boolean;      // 完了フラグ
+  timestamp: number;       // イベント発生時刻
+}
+
+// イベントリスナーの型定義
+export type DockerCommandListener = (event: DockerCommandEvent) => void;
+export type DockerLearningListener = (event: DockerLearningEvent) => void;
+
+// 学習テーマの定義
+export enum DockerLearningTopic {
+  CONTAINER_BASICS = 'container_basics',
+  CONTAINER_VS_VM = 'container_vs_vm',
+  CONTAINER_HOST_RELATION = 'container_host_relation',
+  IMAGES = 'images',
+  VOLUMES = 'volumes',
+  NETWORKS = 'networks',
+  COMPOSE = 'compose'
+}
+
+// 学習ヒントのマッピング
+interface DockerLearningHint {
+  topic: DockerLearningTopic;
+  message: string;
+  commands: string[];
+}
+
+/**
+ * Docker コマンドインタープリター
+ * DockerSimulator のラッパーとして機能し、イベント通知とコンポーネント連携を提供
+ */
+export class DockerCommandInterpreter {
+  private simulator: DockerSimulator;
+  private commandListeners: DockerCommandListener[] = [];
+  private learningListeners: DockerLearningListener[] = [];
+  private learningProgress: Record<DockerLearningTopic, boolean> = {
+    [DockerLearningTopic.CONTAINER_BASICS]: false,
+    [DockerLearningTopic.CONTAINER_VS_VM]: false,
+    [DockerLearningTopic.CONTAINER_HOST_RELATION]: false,
+    [DockerLearningTopic.IMAGES]: false,
+    [DockerLearningTopic.VOLUMES]: false,
+    [DockerLearningTopic.NETWORKS]: false,
+    [DockerLearningTopic.COMPOSE]: false
+  };
+
+  // 学習ヒントのマッピング
+  private learningHints: DockerLearningHint[] = [
+    {
+      topic: DockerLearningTopic.CONTAINER_BASICS,
+      message: 'コンテナは軽量な実行環境です。アプリケーションとその依存関係をパッケージ化しています。',
+      commands: ['docker ps', 'docker run', 'docker start', 'docker stop']
+    },
+    {
+      topic: DockerLearningTopic.CONTAINER_VS_VM,
+      message: 'コンテナは仮想マシン(VM)と異なり、ホストOSのカーネルを共有するため、軽量で高速に起動できます。',
+      commands: ['docker run', 'docker images']
+    },
+    {
+      topic: DockerLearningTopic.CONTAINER_HOST_RELATION,
+      message: 'コンテナはホストマシンと分離されていますが、ポートマッピングやボリュームマウントでホストと連携できます。',
+      commands: ['docker run -p', 'docker run -v']
+    },
+    {
+      topic: DockerLearningTopic.IMAGES,
+      message: 'Dockerイメージはアプリケーションと実行環境を含む読み取り専用のテンプレートです。',
+      commands: ['docker images', 'docker pull', 'docker build', 'docker rmi']
+    },
+    {
+      topic: DockerLearningTopic.VOLUMES,
+      message: 'Dockerボリュームはデータを永続化し、コンテナ間で共有するための仕組みです。',
+      commands: ['docker volume', 'docker run -v']
+    },
+    {
+      topic: DockerLearningTopic.NETWORKS,
+      message: 'Dockerネットワークはコンテナ間の通信を管理し、分離やセキュリティを確保します。',
+      commands: ['docker network', 'docker run --network']
+    },
+    {
+      topic: DockerLearningTopic.COMPOSE,
+      message: 'Docker Composeは複数のコンテナを定義・実行するためのツールです。サービス、ネットワーク、ボリュームを設定できます。',
+      commands: ['docker compose']
+    }
+  ];
+
+  /**
+   * コンストラクタ
+   * @param initialState 初期Docker状態
+   * @param level 初期難易度レベル
+   */
+  constructor(initialState?: DockerState, level: DifficultyLevel = DifficultyLevel.BEGINNER) {
+    this.simulator = new DockerSimulator(initialState, level);
+  }
+
+  /**
+   * コマンド実行
+   * @param command 実行するコマンド文字列
+   * @returns コマンド実行結果
+   */
+  executeCommand(command: string): CommandResult {
+    // 実行前の状態を保存
+    const previousState = this.simulator.getState();
+    
+    // シミュレータでコマンドを実行
+    const result = this.simulator.executeCommand(command);
+    
+    // 実行後の状態を取得
+    const currentState = this.simulator.getState();
+    
+    // コマンドイベント発行
+    const commandEvent: DockerCommandEvent = {
+      command,
+      result,
+      previousState,
+      currentState,
+      timestamp: Date.now()
+    };
+    
+    // コマンドリスナーに通知
+    this.notifyCommandListeners(commandEvent);
+    
+    // 学習進捗をチェック
+    this.checkLearningProgress(command, result);
+    
+    return result;
+  }
+
+  /**
+   * コマンドリスナー追加
+   * @param listener コマンドイベントリスナー
+   */
+  addCommandListener(listener: DockerCommandListener): void {
+    this.commandListeners.push(listener);
+  }
+
+  /**
+   * コマンドリスナー削除
+   * @param listener 削除するリスナー
+   */
+  removeCommandListener(listener: DockerCommandListener): void {
+    this.commandListeners = this.commandListeners.filter(l => l !== listener);
+  }
+
+  /**
+   * 学習リスナー追加
+   * @param listener 学習イベントリスナー
+   */
+  addLearningListener(listener: DockerLearningListener): void {
+    this.learningListeners.push(listener);
+  }
+
+  /**
+   * 学習リスナー削除
+   * @param listener 削除するリスナー
+   */
+  removeLearningListener(listener: DockerLearningListener): void {
+    this.learningListeners = this.learningListeners.filter(l => l !== listener);
+  }
+
+  /**
+   * コマンドリスナーに通知
+   * @param event コマンドイベント
+   */
+  private notifyCommandListeners(event: DockerCommandEvent): void {
+    this.commandListeners.forEach(listener => {
+      try {
+        listener(event);
+      } catch (error) {
+        console.error('Error in command listener:', error);
+      }
+    });
+  }
+
+  /**
+   * 学習リスナーに通知
+   * @param event 学習イベント
+   */
+  private notifyLearningListeners(event: DockerLearningEvent): void {
+    this.learningListeners.forEach(listener => {
+      try {
+        listener(event);
+      } catch (error) {
+        console.error('Error in learning listener:', error);
+      }
+    });
+  }
+
+  /**
+   * 学習進捗をチェック
+   * @param command 実行されたコマンド
+   * @param result コマンド実行結果
+   */
+  private checkLearningProgress(command: string, result: CommandResult): void {
+    if (!result.success) return; // 失敗したコマンドは学習に含めない
+    
+    // 学習ヒントをチェック
+    for (const hint of this.learningHints) {
+      // この学習トピックが未完了で、このコマンドがトピックに関連する場合
+      if (!this.learningProgress[hint.topic] && this.isCommandRelatedToTopic(command, hint.commands)) {
+        // 学習完了としてマーク
+        this.learningProgress[hint.topic] = true;
+        
+        // 学習イベント発行
+        const learningEvent: DockerLearningEvent = {
+          topic: hint.topic,
+          command,
+          level: this.simulator.getDifficultyLevel(),
+          completed: true,
+          timestamp: Date.now()
+        };
+        
+        // 学習リスナーに通知
+        this.notifyLearningListeners(learningEvent);
+        
+        // 関連する学習ヒントを取得
+        const learningHint = hint.message;
+        
+        // 実行結果にヒントを追加（別のプロパティとして）
+        (result as any).learningHint = learningHint;
+        
+        break;
+      }
+    }
+  }
+
+  /**
+   * コマンドが特定の学習トピックに関連しているか確認
+   * @param command 実行されたコマンド
+   * @param relatedCommands トピックに関連するコマンドリスト
+   * @returns 関連がある場合true
+   */
+  private isCommandRelatedToTopic(command: string, relatedCommands: string[]): boolean {
+    return relatedCommands.some(relatedCmd => command.startsWith(relatedCmd));
+  }
+
+  /**
+   * 難易度レベル設定
+   * @param level 新しい難易度レベル
+   */
+  setDifficultyLevel(level: DifficultyLevel): void {
+    this.simulator.setDifficultyLevel(level);
+  }
+
+  /**
+   * 現在の難易度レベル取得
+   * @returns 現在の難易度レベル
+   */
+  getDifficultyLevel(): DifficultyLevel {
+    return this.simulator.getDifficultyLevel();
+  }
+
+  /**
+   * 現在のDocker状態取得
+   * @returns 現在のDocker状態
+   */
+  getState(): DockerState {
+    return this.simulator.getState();
+  }
+
+  /**
+   * Docker状態の設定
+   * @param newState 新しいDocker状態
+   */
+  setState(newState: DockerState): void {
+    this.simulator.setState(newState);
+  }
+
+  /**
+   * 学習トピック情報を取得
+   * @param topic 学習トピック
+   * @returns トピックに関する情報とヒント
+   */
+  getLearningTopicInfo(topic: DockerLearningTopic): DockerLearningHint | null {
+    return this.learningHints.find(hint => hint.topic === topic) || null;
+  }
+
+  /**
+   * すべての学習トピックと進捗状況を取得
+   * @returns トピックと進捗状況のマップ
+   */
+  getLearningProgress(): Record<DockerLearningTopic, boolean> {
+    return {...this.learningProgress};
+  }
+
+  /**
+   * 学習トピックに関連するコマンド例を取得
+   * @param topic 学習トピック
+   * @returns 関連するコマンド例
+   */
+  getRelatedCommandsForTopic(topic: DockerLearningTopic): string[] {
+    const hint = this.learningHints.find(h => h.topic === topic);
+    return hint ? [...hint.commands] : [];
+  }
+
+  /**
+   * コマンド例から学習ヒントを生成
+   * @param command コマンド文字列
+   * @returns 関連する学習ヒント（ない場合はnull）
+   */
+  getHintForCommand(command: string): string | null {
+    for (const hint of this.learningHints) {
+      if (this.isCommandRelatedToTopic(command, hint.commands)) {
+        return hint.message;
+      }
+    }
+    return null;
+  }
+}

--- a/container/claudecode/studyGIt/src/components/DockerEventEmitter.ts
+++ b/container/claudecode/studyGIt/src/components/DockerEventEmitter.ts
@@ -1,0 +1,204 @@
+/**
+ * DockerEventEmitter.ts
+ * Docker操作イベントの発行と購読を管理する共通システム
+ */
+
+import { DockerState, DockerStateChangeEvent, DockerEventObserver, DockerEventEmitter } from './DockerTypes';
+
+/**
+ * Docker イベントバス実装
+ * 各コンポーネント間の通信を仲介し、一貫性のあるイベント処理を提供
+ */
+export class DockerEventBus implements DockerEventEmitter {
+  private observers: DockerEventObserver[] = [];
+  private currentState: DockerState;
+
+  /**
+   * コンストラクタ
+   * @param initialState 初期Docker状態
+   */
+  constructor(initialState: DockerState) {
+    this.currentState = { ...initialState };
+  }
+
+  /**
+   * オブザーバー登録
+   * @param observer 登録するDockerEventObserver
+   */
+  addObserver(observer: DockerEventObserver): void {
+    if (!this.observers.includes(observer)) {
+      this.observers.push(observer);
+    }
+  }
+
+  /**
+   * オブザーバー削除
+   * @param observer 削除するDockerEventObserver
+   */
+  removeObserver(observer: DockerEventObserver): void {
+    this.observers = this.observers.filter(o => o !== observer);
+  }
+
+  /**
+   * イベント発行
+   * @param event 発行するDockerStateChangeEvent
+   */
+  emitEvent(event: DockerStateChangeEvent): void {
+    // すべてのオブザーバーに通知
+    this.observers.forEach(observer => {
+      try {
+        observer.notify(event);
+      } catch (error) {
+        console.error('Error notifying observer:', error);
+      }
+    });
+  }
+
+  /**
+   * 状態更新とイベント発行
+   * @param newState 新しいDocker状態
+   * @param event 関連するイベント
+   */
+  updateState(newState: DockerState, event?: DockerStateChangeEvent): void {
+    // 前の状態を保存
+    const previousState = { ...this.currentState };
+    
+    // 新しい状態を設定
+    this.currentState = { ...newState };
+    
+    // イベントがない場合は、状態変更に基づいてイベントを推測
+    if (!event) {
+      event = this.inferEventFromStateChange(previousState, newState);
+    }
+    
+    // イベント発行
+    if (event) {
+      this.emitEvent(event);
+    }
+  }
+
+  /**
+   * 状態変更からイベントを推測
+   * @param previousState 前の状態
+   * @param newState 新しい状態
+   * @returns 推測されたイベント
+   */
+  private inferEventFromStateChange(previousState: DockerState, newState: DockerState): DockerStateChangeEvent | undefined {
+    // コンテナ変更のチェック
+    const prevContainers = new Set(previousState.containers.map(c => c.id));
+    const newContainers = new Set(newState.containers.map(c => c.id));
+    
+    // 追加されたコンテナ
+    const addedContainers = [...newState.containers].filter(c => !prevContainers.has(c.id));
+    if (addedContainers.length > 0) {
+      return {
+        type: 'container_created',
+        payload: { containers: addedContainers }
+      };
+    }
+    
+    // 削除されたコンテナ
+    const removedContainers = [...previousState.containers].filter(c => !newContainers.has(c.id));
+    if (removedContainers.length > 0) {
+      return {
+        type: 'container_removed',
+        payload: { containers: removedContainers }
+      };
+    }
+    
+    // ステータス変更のチェック
+    for (const newContainer of newState.containers) {
+      const prevContainer = previousState.containers.find(c => c.id === newContainer.id);
+      if (prevContainer && prevContainer.status !== newContainer.status) {
+        if (newContainer.status === 'running') {
+          return {
+            type: 'container_started',
+            payload: { container: newContainer }
+          };
+        } else if (newContainer.status === 'exited' || newContainer.status === 'paused') {
+          return {
+            type: 'container_stopped',
+            payload: { container: newContainer }
+          };
+        }
+      }
+    }
+    
+    // イメージ変更のチェック
+    const prevImages = new Set(previousState.images);
+    const newImages = new Set(newState.images);
+    
+    // 追加されたイメージ
+    const addedImages = [...newState.images].filter(img => !prevImages.has(img));
+    if (addedImages.length > 0) {
+      return {
+        type: 'image_pulled',
+        payload: { images: addedImages }
+      };
+    }
+    
+    // 削除されたイメージ
+    const removedImages = [...previousState.images].filter(img => !newImages.has(img));
+    if (removedImages.length > 0) {
+      return {
+        type: 'image_removed',
+        payload: { images: removedImages }
+      };
+    }
+    
+    // ネットワーク変更のチェック
+    const prevNetworks = new Set(previousState.networks);
+    const newNetworks = new Set(newState.networks);
+    
+    // 追加されたネットワーク
+    const addedNetworks = [...newState.networks].filter(net => !prevNetworks.has(net));
+    if (addedNetworks.length > 0) {
+      return {
+        type: 'network_created',
+        payload: { networks: addedNetworks }
+      };
+    }
+    
+    // 削除されたネットワーク
+    const removedNetworks = [...previousState.networks].filter(net => !newNetworks.has(net));
+    if (removedNetworks.length > 0) {
+      return {
+        type: 'network_removed',
+        payload: { networks: removedNetworks }
+      };
+    }
+    
+    // ボリューム変更のチェック
+    const prevVolumes = new Set(previousState.volumes);
+    const newVolumes = new Set(newState.volumes);
+    
+    // 追加されたボリューム
+    const addedVolumes = [...newState.volumes].filter(vol => !prevVolumes.has(vol));
+    if (addedVolumes.length > 0) {
+      return {
+        type: 'volume_created',
+        payload: { volumes: addedVolumes }
+      };
+    }
+    
+    // 削除されたボリューム
+    const removedVolumes = [...previousState.volumes].filter(vol => !newVolumes.has(vol));
+    if (removedVolumes.length > 0) {
+      return {
+        type: 'volume_removed',
+        payload: { volumes: removedVolumes }
+      };
+    }
+    
+    // 特定の変更が検出されない場合
+    return undefined;
+  }
+
+  /**
+   * 現在の状態を取得
+   * @returns 現在のDocker状態
+   */
+  getState(): DockerState {
+    return { ...this.currentState };
+  }
+}

--- a/container/claudecode/studyGIt/src/components/DockerGuide.module.css
+++ b/container/claudecode/studyGIt/src/components/DockerGuide.module.css
@@ -1,0 +1,420 @@
+.dockerGuide {
+  display: flex;
+  flex-direction: column;
+  max-width: 1000px;
+  margin: 0 auto;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.title {
+  color: var(--primary);
+  margin-bottom: 1.5rem;
+  text-align: center;
+  position: relative;
+}
+
+.title::after {
+  content: attr(data-version);
+  position: absolute;
+  top: 5px;
+  right: -40px;
+  font-size: 0.7rem;
+  background-color: #0db7ed;
+  color: white;
+  padding: 2px 6px;
+  border-radius: 10px;
+  transform: rotate(15deg);
+}
+
+.progressBar {
+  display: flex;
+  justify-content: space-between;
+  margin: 2rem 0;
+  position: relative;
+  overflow-x: auto;
+  padding-bottom: 1rem;
+}
+
+/* 適応学習コンテンツ用のスタイル */
+.adaptiveLearning {
+  margin-top: 20px;
+  padding: 15px;
+  background-color: #f8f9fa;
+  border-left: 4px solid #0db7ed;
+  border-radius: 4px;
+}
+
+.previousKnowledge {
+  font-size: 0.95em;
+}
+
+.previousKnowledge h4 {
+  color: #0077aa;
+  margin-top: 0;
+  margin-bottom: 10px;
+}
+
+/* 上級者向け追加コンテンツ */
+.advancedContent {
+  margin-top: 25px;
+  padding: 15px;
+  background-color: #f0f7fa;
+  border-left: 4px solid #ff3860;
+  border-radius: 4px;
+}
+
+.advancedContent h4 {
+  color: #d14;
+  margin-top: 0;
+  margin-bottom: 10px;
+}
+
+/* ユーザーレベル表示 */
+.userLevel {
+  display: flex;
+  align-items: center;
+  margin-top: 5px;
+  font-size: 0.9em;
+  color: #666;
+}
+
+/* バッジ表示 */
+.badges {
+  display: flex;
+  margin-left: 10px;
+}
+
+.badge {
+  font-size: 1.2em;
+  margin-left: 5px;
+  cursor: help;
+}
+
+/* 言語セレクター */
+.languageSelector {
+  margin-left: 10px;
+  padding: 4px 8px;
+  border-radius: 4px;
+  border: 1px solid #ddd;
+  background-color: #f8f9fa;
+  font-size: 0.9em;
+  cursor: pointer;
+}
+
+.progressBar::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background-color: #e0e0e0;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 0;
+}
+
+.progressStep {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+  z-index: 1;
+  cursor: pointer;
+  min-width: 100px;
+  user-select: none;
+}
+
+.stepNumber {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background-color: #e0e0e0;
+  color: #666;
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+  transition: all 0.3s ease;
+}
+
+.stepTitle {
+  font-size: 0.75rem;
+  text-align: center;
+  color: #666;
+  transition: all 0.3s ease;
+  max-width: 100px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.progressStep.active .stepNumber {
+  background-color: var(--primary);
+  color: white;
+  transform: scale(1.2);
+}
+
+.progressStep.active .stepTitle {
+  color: var(--primary);
+  font-weight: bold;
+}
+
+.progressStep.completed .stepNumber {
+  background-color: var(--primary);
+  color: white;
+}
+
+.developmentPhase {
+  background-color: #f5f5f5;
+  padding: 0.75rem 1.5rem;
+  border-radius: var(--border-radius);
+  margin-bottom: 2rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.viewToggle {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.viewToggleButton {
+  background-color: #e0e0e0;
+  border: none;
+  padding: 0.4rem 0.8rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: all 0.2s ease;
+}
+
+.viewToggleButton:hover {
+  background-color: #d0d0d0;
+}
+
+.viewToggleButton.active {
+  background-color: var(--primary);
+  color: white;
+}
+
+.content {
+  margin-bottom: 2rem;
+}
+
+.section {
+  margin-bottom: 2.5rem;
+}
+
+.section h3 {
+  color: var(--primary);
+  margin-bottom: 1rem;
+  border-bottom: 1px solid #e0e0e0;
+  padding-bottom: 0.5rem;
+}
+
+.codeBlock {
+  background-color: #282c34;
+  border-radius: var(--border-radius);
+  overflow: hidden;
+  margin: 1.5rem 0;
+}
+
+.codeBlock pre {
+  margin: 0;
+  padding: 1.5rem;
+  overflow-x: auto;
+  color: #abb2bf;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.keyPoints {
+  background-color: #f0f7ff;
+  border: 1px solid #cce5ff;
+  border-left: 4px solid #0078d7;
+  border-radius: var(--border-radius);
+  padding: 1.2rem;
+  margin: 1.5rem 0;
+}
+
+.keyPoints h4 {
+  color: #0078d7;
+  margin-top: 0;
+  margin-bottom: 0.8rem;
+}
+
+.keyPoints ul {
+  margin: 0;
+  padding-left: 1.5rem;
+}
+
+.keyPoints li {
+  margin-bottom: 0.5rem;
+}
+
+.file {
+  background-color: #f8f9fa;
+  border: 1px solid #e0e0e0;
+  border-radius: var(--border-radius);
+  margin-bottom: 1rem;
+  overflow: hidden;
+}
+
+.fileName {
+  background-color: #e0e0e0;
+  padding: 0.5rem 1rem;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-weight: 500;
+  font-size: 0.9rem;
+}
+
+.file pre {
+  margin: 0;
+  padding: 1rem;
+  overflow-x: auto;
+}
+
+.file code {
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 0.9rem;
+}
+
+.newCode {
+  background-color: #e6ffed;
+  display: block;
+}
+
+.oldCode {
+  background-color: #ffeef0;
+  display: block;
+  text-decoration: line-through;
+}
+
+.highlightedCode {
+  background-color: #fffbdd;
+}
+
+.navigation {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 2rem;
+}
+
+.navButton {
+  background-color: var(--primary);
+  color: white;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: var(--border-radius);
+  cursor: pointer;
+  font-weight: 500;
+  transition: all 0.2s ease;
+}
+
+.navButton:hover {
+  background-color: var(--primary-darker);
+}
+
+.navButton:disabled {
+  background-color: #e0e0e0;
+  color: #a0a0a0;
+  cursor: not-allowed;
+}
+
+.diagram {
+  width: 100%;
+  max-width: 800px;
+  margin: 0 auto;
+  display: block;
+  border-radius: var(--border-radius);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.diagramCaption {
+  text-align: center;
+  color: #666;
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.dockerExample {
+  display: flex;
+  flex-direction: column;
+  margin: 2rem 0;
+}
+
+.dockerExampleImg {
+  max-width: 100%;
+  border-radius: var(--border-radius);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  align-self: center;
+}
+
+.compareTable {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+}
+
+.compareTable th,
+.compareTable td {
+  padding: 1rem;
+  border: 1px solid #e0e0e0;
+  text-align: left;
+}
+
+.compareTable th {
+  background-color: #f5f5f5;
+  font-weight: 600;
+}
+
+.compareTable tr:nth-child(even) {
+  background-color: #f9f9f9;
+}
+
+.iconRow {
+  display: flex;
+  justify-content: space-around;
+  margin: 2rem 0;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+}
+
+.iconBox {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 120px;
+  text-align: center;
+}
+
+.iconBox .icon {
+  font-size: 2.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.iconBox .label {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #333;
+}
+
+/* Media queries for responsive design */
+@media (max-width: 768px) {
+  .progressBar {
+    justify-content: flex-start;
+    gap: 1.5rem;
+  }
+  
+  .developmentPhase {
+    flex-direction: column;
+    gap: 1rem;
+  }
+  
+  .iconRow {
+    justify-content: center;
+  }
+}

--- a/container/claudecode/studyGIt/src/components/DockerGuide.tsx
+++ b/container/claudecode/studyGIt/src/components/DockerGuide.tsx
@@ -1,0 +1,1552 @@
+"use client";
+
+import React, { useState, useEffect } from 'react';
+import { motion } from 'framer-motion';
+import styles from './DockerGuide.module.css';
+import DEFAULT_DOCKER_STATE from './DefaultDocker';
+import { useDockerLearning } from './DockerLearningContext';
+import { DifficultyLevel } from './DockerSimulator';
+
+const DockerGuide = () => {
+  const [currentStep, setCurrentStep] = useState(0);
+  const [viewMode, setViewMode] = useState('graphic'); // 'graphic' または 'text'
+  const [animationEnabled, setAnimationEnabled] = useState(true);
+  
+  // DockerLearningContextから学習進捗を取得
+  const { 
+    progress, 
+    completeTopic, 
+    topics, 
+    currentTopicId,
+    setCurrentTopic,
+    getNextRecommendedTopic,
+    setLanguage 
+  } = useDockerLearning();
+  
+  // 言語切り替え処理
+  const handleLanguageChange = (lang: 'ja' | 'en') => {
+    setLanguage(lang);
+    // ここで言語に応じたコンテンツ切り替えロジックを実装
+    // 実装例: 各ステップの内容を言語に応じて切り替える
+    console.log(`Language changed to: ${lang}`);
+  };
+  
+  const steps = [
+    {
+      title: "Dockerとは",
+      development: "基礎概念",
+      content: (
+        <div className={styles.section}>
+          <h3>Dockerとは何か？</h3>
+          <p>
+            Dockerは、アプリケーションを開発・配布・実行するためのオープンプラットフォームです。
+            環境を<strong>コンテナ</strong>として分離・パッケージ化することで、どこでも同じように動作することを保証します。
+            「ローカルでは動くけど本番環境では動かない」という問題を解決する技術です。
+          </p>
+          
+          <motion.div 
+            className={styles.iconRow}
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, staggerChildren: 0.1 }}
+          >
+            <motion.div className={styles.iconBox} whileHover={{ scale: 1.1 }}>
+              <div className={styles.icon}>🐳</div>
+              <div className={styles.label}>Docker</div>
+            </motion.div>
+            <motion.div className={styles.iconBox} whileHover={{ scale: 1.1 }}>
+              <div className={styles.icon}>📦</div>
+              <div className={styles.label}>コンテナ</div>
+            </motion.div>
+            <motion.div className={styles.iconBox} whileHover={{ scale: 1.1 }}>
+              <div className={styles.icon}>🖼️</div>
+              <div className={styles.label}>イメージ</div>
+            </motion.div>
+            <motion.div className={styles.iconBox} whileHover={{ scale: 1.1 }}>
+              <div className={styles.icon}>📄</div>
+              <div className={styles.label}>Dockerfile</div>
+            </motion.div>
+            <motion.div className={styles.iconBox} whileHover={{ scale: 1.1 }}>
+              <div className={styles.icon}>🔄</div>
+              <div className={styles.label}>Docker Compose</div>
+            </motion.div>
+          </motion.div>
+          
+          <div className={styles.interactiveSection}>
+            <h4>コンテナとは何か？</h4>
+            <p>
+              コンテナはアプリケーションとその依存関係（ライブラリやランタイム環境など）を一つのパッケージにまとめたものです。
+              コンテナ内のアプリケーションは、ホスト環境から隔離された独自の仮想環境で実行されます。
+            </p>
+            
+            <div className={styles.conceptExplanation}>
+              <div className={styles.conceptTitle}>
+                <span className={styles.conceptIcon}>🔍</span>
+                <h5>重要ポイント：コンテナとは？</h5>
+              </div>
+              <ul>
+                <li><strong>独立した実行環境</strong>：自己完結型の実行単位</li>
+                <li><strong>アプリケーション＋依存関係</strong>：必要なものだけを含む</li>
+                <li><strong>ポータブル</strong>：どこでも同じように動作する</li>
+                <li><strong>軽量</strong>：仮想マシンよりも少ないリソースで稼働</li>
+                <li><strong>短命</strong>：使い捨てが前提（ステートレス設計）</li>
+              </ul>
+            </div>
+          </div>
+          
+          <h4>コンテナと仮想マシンの違い</h4>
+          
+          <div className={styles.comparisonDiagram}>
+            <div className={styles.comparisonColumn}>
+              <h5 className={styles.comparisonTitle}>コンテナ</h5>
+              <div className={styles.comparisonImage}>
+                <motion.div 
+                  className={styles.containerArchitecture}
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  transition={{ duration: 0.5 }}
+                >
+                  <div className={styles.containerApps}>
+                    <div className={styles.containerApp}>App A</div>
+                    <div className={styles.containerApp}>App B</div>
+                    <div className={styles.containerApp}>App C</div>
+                  </div>
+                  <div className={styles.containerRuntime}>Docker Engine</div>
+                  <div className={styles.hostOS}>ホストOS</div>
+                  <div className={styles.hostHardware}>物理ハードウェア</div>
+                </motion.div>
+              </div>
+              <div className={styles.comparisonPoints}>
+                <ul>
+                  <li>OSカーネルを共有</li>
+                  <li>必要なライブラリのみをパッケージ化</li>
+                  <li>起動時間：数秒</li>
+                  <li>サイズ：数MB～数百MB</li>
+                </ul>
+              </div>
+            </div>
+            
+            <div className={styles.comparisonColumn}>
+              <h5 className={styles.comparisonTitle}>仮想マシン</h5>
+              <div className={styles.comparisonImage}>
+                <motion.div 
+                  className={styles.vmArchitecture}
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  transition={{ duration: 0.5, delay: 0.2 }}
+                >
+                  <div className={styles.vmGroup}>
+                    <div className={styles.vm}>
+                      <div className={styles.vmApp}>App A</div>
+                      <div className={styles.vmOS}>ゲストOS</div>
+                    </div>
+                    <div className={styles.vm}>
+                      <div className={styles.vmApp}>App B</div>
+                      <div className={styles.vmOS}>ゲストOS</div>
+                    </div>
+                    <div className={styles.vm}>
+                      <div className={styles.vmApp}>App C</div>
+                      <div className={styles.vmOS}>ゲストOS</div>
+                    </div>
+                  </div>
+                  <div className={styles.hypervisor}>ハイパーバイザー</div>
+                  <div className={styles.hostOS}>ホストOS</div>
+                  <div className={styles.hostHardware}>物理ハードウェア</div>
+                </motion.div>
+              </div>
+              <div className={styles.comparisonPoints}>
+                <ul>
+                  <li>独自のOSを実行</li>
+                  <li>完全な仮想化環境</li>
+                  <li>起動時間：数分</li>
+                  <li>サイズ：数GB～数十GB</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+          
+          <table className={styles.compareTable}>
+            <thead>
+              <tr>
+                <th></th>
+                <th>コンテナ</th>
+                <th>仮想マシン（VM）</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><strong>起動時間</strong></td>
+                <td>数秒</td>
+                <td>数分</td>
+              </tr>
+              <tr>
+                <td><strong>サイズ</strong></td>
+                <td>数MB～数百MB</td>
+                <td>数GB～数十GB</td>
+              </tr>
+              <tr>
+                <td><strong>リソース効率</strong></td>
+                <td>非常に高い</td>
+                <td>中程度</td>
+              </tr>
+              <tr>
+                <td><strong>分離レベル</strong></td>
+                <td>プロセスレベル</td>
+                <td>ハードウェアレベル</td>
+              </tr>
+              <tr>
+                <td><strong>OS</strong></td>
+                <td>ホストOSのカーネルを共有</td>
+                <td>ゲストOSが必要</td>
+              </tr>
+              <tr>
+                <td><strong>セキュリティ</strong></td>
+                <td>やや低い（共有カーネル）</td>
+                <td>高い（完全分離）</td>
+              </tr>
+              <tr>
+                <td><strong>用途</strong></td>
+                <td>マイクロサービス、CI/CD</td>
+                <td>異なるOS、レガシーアプリ</td>
+              </tr>
+            </tbody>
+          </table>
+          
+          <div className={styles.hostRelationship}>
+            <h4>コンテナとホストの関係</h4>
+            <p>
+              コンテナはホストOSのカーネルを共有しながら、隔離された実行環境を提供します。
+              この仕組みにより、軽量かつ高速な動作を実現しています。
+            </p>
+            
+            <div className={styles.hostRelationshipDiagram}>
+              <motion.div 
+                className={styles.hostRelationshipContainer}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                transition={{ duration: 0.8 }}
+              >
+                <div className={styles.hostSystem}>
+                  <div className={styles.hostTitle}>ホストシステム</div>
+                  <div className={styles.hostKernel}>
+                    <span>Linuxカーネル</span>
+                    <div className={styles.kernelFeatures}>
+                      <div className={styles.kernelFeature}>namespaces</div>
+                      <div className={styles.kernelFeature}>cgroups</div>
+                      <div className={styles.kernelFeature}>capabilities</div>
+                    </div>
+                  </div>
+                  
+                  <div className={styles.containersGroup}>
+                    <motion.div 
+                      className={styles.containerBox}
+                      whileHover={{ y: -5 }}
+                    >
+                      <div className={styles.containerHeader}>コンテナA</div>
+                      <div className={styles.containerContent}>
+                        <div>App A</div>
+                        <div>Libs</div>
+                      </div>
+                    </motion.div>
+                    <motion.div 
+                      className={styles.containerBox}
+                      whileHover={{ y: -5 }}
+                    >
+                      <div className={styles.containerHeader}>コンテナB</div>
+                      <div className={styles.containerContent}>
+                        <div>App B</div>
+                        <div>Libs</div>
+                      </div>
+                    </motion.div>
+                    <motion.div 
+                      className={styles.containerBox}
+                      whileHover={{ y: -5 }}
+                    >
+                      <div className={styles.containerHeader}>コンテナC</div>
+                      <div className={styles.containerContent}>
+                        <div>App C</div>
+                        <div>Libs</div>
+                      </div>
+                    </motion.div>
+                  </div>
+                </div>
+              </motion.div>
+            </div>
+            
+            <div className={styles.conceptExplanation}>
+              <div className={styles.conceptTitle}>
+                <span className={styles.conceptIcon}>🔐</span>
+                <h5>コンテナの隔離技術</h5>
+              </div>
+              <ul>
+                <li><strong>namespaces</strong>：プロセス、ネットワーク、ファイルシステムなどの分離</li>
+                <li><strong>cgroups</strong>：CPUやメモリなどのリソース制限</li>
+                <li><strong>capabilities</strong>：特権操作の制限</li>
+                <li><strong>seccomp</strong>：システムコールのフィルタリング</li>
+              </ul>
+            </div>
+          </div>
+          
+          <div className={styles.keyPoints}>
+            <h4>Dockerの主要概念</h4>
+            <ul>
+              <li><strong>イメージ</strong>: アプリケーションと実行環境をパッケージ化したテンプレート（読み取り専用）</li>
+              <li><strong>コンテナ</strong>: イメージの実行インスタンス（読み書き可能なレイヤーを追加）</li>
+              <li><strong>Dockerfile</strong>: イメージをビルドするための指示書（コード化されたレシピ）</li>
+              <li><strong>Docker Compose</strong>: 複数のコンテナを定義・実行するためのツール（アプリ構成管理）</li>
+              <li><strong>レジストリ</strong>: イメージを保存・共有するためのリポジトリ（配布拠点）</li>
+              <li><strong>ボリューム</strong>: コンテナのデータを永続化する仕組み（データの永続性）</li>
+              <li><strong>ネットワーク</strong>: コンテナ間の通信を管理する仕組み（分離通信路）</li>
+            </ul>
+          </div>
+          
+          <div className={styles.dockerExample}>
+            <img 
+              src="https://docs.docker.com/engine/images/architecture.svg" 
+              alt="Docker Architecture" 
+              className={styles.dockerExampleImg}
+            />
+            <div className={styles.diagramCaption}>
+              Docker アーキテクチャ概要（出典: Docker公式ドキュメント）
+            </div>
+          </div>
+          
+          <div className={styles.interactiveLearning}>
+            <h4>理解度チェック</h4>
+            <div className={styles.questionBox}>
+              <p>質問: コンテナと仮想マシンの最も重要な違いは何ですか？</p>
+              <details>
+                <summary>答えを見る</summary>
+                <div className={styles.answerBox}>
+                  <p>コンテナはホストOSのカーネルを共有するため、軽量で高速に起動できますが、仮想マシンは独自のゲストOSを持ち、完全に分離された環境を提供します。コンテナはアプリケーションとその依存関係のみを含み、仮想マシンは完全なOSとアプリケーションを含みます。</p>
+                </div>
+              </details>
+            </div>
+          </div>
+        </div>
+      )
+    },
+    {
+      title: "Docker基本コマンド",
+      development: "基本操作",
+      content: (
+        <div className={styles.section}>
+          <h3>Docker基本コマンド</h3>
+          <p>
+            Dockerを使いこなすためには、基本的なコマンドを理解することが重要です。
+            以下は最も頻繁に使用されるDockerコマンドです。
+          </p>
+          
+          <h4>コンテナ操作</h4>
+          <div className={styles.codeBlock}>
+            <pre>
+              <code>
+                {`# コンテナの起動
+$ docker run -d --name my-container -p 8080:80 nginx
+
+# コンテナ一覧表示
+$ docker ps        # 実行中のコンテナのみ
+$ docker ps -a     # 全てのコンテナ
+
+# コンテナの停止
+$ docker stop my-container
+
+# コンテナの再開
+$ docker start my-container
+
+# コンテナの削除
+$ docker rm my-container
+$ docker rm -f my-container   # 実行中でも強制削除`}
+              </code>
+            </pre>
+          </div>
+          
+          <h4>イメージ操作</h4>
+          <div className={styles.codeBlock}>
+            <pre>
+              <code>
+                {`# イメージのダウンロード
+$ docker pull nginx:latest
+
+# イメージ一覧表示
+$ docker images
+
+# イメージのビルド
+$ docker build -t my-app:1.0 .
+
+# イメージの削除
+$ docker rmi nginx:latest`}
+              </code>
+            </pre>
+          </div>
+          
+          <div className={styles.keyPoints}>
+            <h4>コマンドオプションの意味</h4>
+            <ul>
+              <li><code>-d</code>: デタッチドモード（バックグラウンドで実行）</li>
+              <li><code>--name</code>: コンテナに名前をつける</li>
+              <li><code>-p</code>: ポートマッピング（ホスト:コンテナ）</li>
+              <li><code>-v</code>: ボリュームマウント（ホスト:コンテナ）</li>
+              <li><code>-e</code>: 環境変数を設定</li>
+              <li><code>-t</code>: イメージにタグをつける</li>
+              <li><code>-f</code>: 強制実行（例: 実行中のコンテナを強制削除）</li>
+            </ul>
+          </div>
+          
+          <h4>コンテナとの対話</h4>
+          <div className={styles.codeBlock}>
+            <pre>
+              <code>
+                {`# 実行中のコンテナでコマンドを実行
+$ docker exec my-container ls -la
+
+# コンテナ内でシェルを起動
+$ docker exec -it my-container bash
+
+# コンテナのログを表示
+$ docker logs my-container
+
+# コンテナのログをリアルタイム表示（follow）
+$ docker logs -f my-container`}
+              </code>
+            </pre>
+          </div>
+          
+          <div className={styles.keyPoints}>
+            <h4>コンテナライフサイクル</h4>
+            <ul>
+              <li><strong>created</strong>: 作成された状態</li>
+              <li><strong>running</strong>: 実行中の状態</li>
+              <li><strong>paused</strong>: 一時停止状態</li>
+              <li><strong>exited</strong>: 停止状態</li>
+              <li><strong>dead</strong>: 削除できない問題のある状態</li>
+            </ul>
+          </div>
+        </div>
+      )
+    },
+    {
+      title: "Dockerfile",
+      development: "イメージ構築",
+      content: (
+        <div className={styles.section}>
+          <h3>Dockerfile - Dockerイメージ定義ファイル</h3>
+          <p>
+            Dockerfileは、Dockerイメージをビルドするための指示書です。
+            一連のコマンドを記述することで、再現性の高いイメージを作成できます。
+          </p>
+          
+          <h4>基本的なDockerfile</h4>
+          <div className={styles.codeBlock}>
+            <pre>
+              <code>
+                {`# ベースイメージを指定
+FROM node:18-alpine
+
+# 作業ディレクトリを設定
+WORKDIR /app
+
+# パッケージ管理ファイルをコピー
+COPY package*.json ./
+
+# 依存関係をインストール
+RUN npm install
+
+# ソースコードをコピー
+COPY . .
+
+# ポート公開
+EXPOSE 3000
+
+# アプリケーション起動コマンド
+CMD ["npm", "start"]`}
+              </code>
+            </pre>
+          </div>
+          
+          <div className={styles.keyPoints}>
+            <h4>主要なDockerfile命令</h4>
+            <ul>
+              <li><code>FROM</code>: ベースイメージを指定</li>
+              <li><code>WORKDIR</code>: 作業ディレクトリを設定</li>
+              <li><code>COPY</code>: ホストからコンテナにファイルをコピー</li>
+              <li><code>ADD</code>: ファイルをコピーし、tarの展開なども可能</li>
+              <li><code>RUN</code>: コマンドを実行し、結果を新レイヤーとして保存</li>
+              <li><code>ENV</code>: 環境変数を設定</li>
+              <li><code>EXPOSE</code>: コンテナがリッスンするポートを指定</li>
+              <li><code>CMD</code>: コンテナ起動時のデフォルトコマンド</li>
+              <li><code>ENTRYPOINT</code>: コンテナ起動時に必ず実行されるコマンド</li>
+            </ul>
+          </div>
+          
+          <h4>マルチステージビルド</h4>
+          <p>
+            マルチステージビルドを使用すると、ビルドに必要なツールと実行に必要な環境を分離でき、
+            最終的なイメージサイズを小さくできます。
+          </p>
+          <div className={styles.codeBlock}>
+            <pre>
+              <code>
+                {`# ビルドステージ
+FROM node:18-alpine AS build
+
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+# 実行ステージ
+FROM nginx:alpine
+COPY --from=build /app/build /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]`}
+              </code>
+            </pre>
+          </div>
+          
+          <div className={styles.keyPoints}>
+            <h4>Dockerfileのベストプラクティス</h4>
+            <ul>
+              <li><strong>レイヤーの最小化</strong>: RUN, COPY, ADDは新しいレイヤーを作成します</li>
+              <li><strong>キャッシュの活用</strong>: 頻繁に変更されないものを先に配置</li>
+              <li><strong>適切なベースイメージ</strong>: 最小限のイメージ（alpine等）を使用</li>
+              <li><strong>.dockerignore</strong>: 不要なファイルをビルドに含めない</li>
+              <li><strong>非rootユーザー</strong>: セキュリティ向上のために特権のないユーザーを使用</li>
+              <li><strong>マルチステージビルド</strong>: ビルドツールと実行環境の分離</li>
+            </ul>
+          </div>
+        </div>
+      )
+    },
+    {
+      title: "Docker Compose",
+      development: "複数コンテナ構成",
+      content: (
+        <div className={styles.section}>
+          <h3>Docker Compose - 複数コンテナの管理</h3>
+          <p>
+            Docker Composeは、複数のコンテナからなるアプリケーションを定義・実行するためのツールです。
+            YAMLファイルを使用して、サービス、ネットワーク、ボリュームを設定します。
+          </p>
+          
+          <h4>基本的なdocker-compose.yml</h4>
+          <div className={styles.codeBlock}>
+            <pre>
+              <code>
+                {`version: '3.8'
+
+services:
+  app:
+    build: .
+    ports:
+      - "3000:3000"
+    volumes:
+      - .:/app
+      - /app/node_modules
+    environment:
+      - NODE_ENV=development
+    depends_on:
+      - db
+      
+  db:
+    image: postgres:13
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_USER=user
+      - POSTGRES_DB=myapp
+      
+  redis:
+    image: redis:alpine
+    ports:
+      - "6379:6379"
+      
+volumes:
+  postgres-data:`}
+              </code>
+            </pre>
+          </div>
+          
+          <div className={styles.keyPoints}>
+            <h4>Docker Compose 基本コマンド</h4>
+            <ul>
+              <li><code>docker-compose up</code>: サービスを起動</li>
+              <li><code>docker-compose up -d</code>: バックグラウンドで起動</li>
+              <li><code>docker-compose down</code>: サービスを停止・削除</li>
+              <li><code>docker-compose logs</code>: サービスのログを表示</li>
+              <li><code>docker-compose exec service_name command</code>: サービスでコマンドを実行</li>
+              <li><code>docker-compose build</code>: サービスをビルド</li>
+              <li><code>docker-compose ps</code>: サービスの状態を確認</li>
+            </ul>
+          </div>
+          
+          <div className={styles.file}>
+            <div className={styles.fileName}>このプロジェクトのdocker-compose.yml</div>
+            <pre>
+              <code>
+                {`version: '3.8'
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: git-playground
+    ports:
+      - "3000:3000"
+    volumes:
+      - .:/app:z,U
+      - /app/node_modules
+    user: "root:root"
+    environment:
+      - NODE_ENV=development
+      - NEXT_PUBLIC_HOST_URL=mcp.shift-terminus.com
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s`}
+              </code>
+            </pre>
+          </div>
+          
+          <div className={styles.keyPoints}>
+            <h4>Docker Compose 主要要素</h4>
+            <ul>
+              <li><strong>services</strong>: アプリケーションを構成するコンテナ群</li>
+              <li><strong>volumes</strong>: データの永続化と共有のための仕組み</li>
+              <li><strong>networks</strong>: コンテナ間通信のためのネットワーク設定</li>
+              <li><strong>depends_on</strong>: サービス間の依存関係</li>
+              <li><strong>environment</strong>: 環境変数設定</li>
+              <li><strong>ports</strong>: ポートマッピング</li>
+              <li><strong>build</strong>: Dockerfileからのビルド設定</li>
+            </ul>
+          </div>
+          
+          <p>
+            Docker Composeを使えば、開発環境を簡単に共有でき、「私の環境では動いている」問題を解消します。
+            チーム全員が同じ環境で開発できるのは、大きなメリットです。
+          </p>
+        </div>
+      )
+    },
+    {
+      title: "Docker ネットワーク",
+      development: "コンテナ間通信",
+      content: (
+        <div className={styles.section}>
+          <h3>Docker ネットワーク - コンテナ間通信</h3>
+          <p>
+            Dockerネットワークは、コンテナ間の通信や外部へのアクセスを管理する仕組みです。
+            適切なネットワーク設計は、セキュリティと柔軟性の両方において重要です。
+          </p>
+          
+          <h4>ネットワークタイプ</h4>
+          <table className={styles.compareTable}>
+            <thead>
+              <tr>
+                <th>ネットワークタイプ</th>
+                <th>説明</th>
+                <th>ユースケース</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><strong>bridge</strong></td>
+                <td>デフォルトのネットワーク。独立した内部ネットワークを作成</td>
+                <td>単一ホストでの複数コンテナ間通信</td>
+              </tr>
+              <tr>
+                <td><strong>host</strong></td>
+                <td>ホストのネットワークをコンテナが直接使用</td>
+                <td>最高のネットワークパフォーマンスが必要な場合</td>
+              </tr>
+              <tr>
+                <td><strong>none</strong></td>
+                <td>ネットワーク接続なし</td>
+                <td>完全に分離されたコンテナが必要な場合</td>
+              </tr>
+              <tr>
+                <td><strong>overlay</strong></td>
+                <td>複数のDockerホスト間でのネットワーク</td>
+                <td>Swarmモードでの分散アプリケーション</td>
+              </tr>
+              <tr>
+                <td><strong>macvlan</strong></td>
+                <td>コンテナにMACアドレスを割り当て、物理デバイスのように扱う</td>
+                <td>レガシーアプリケーションの移行</td>
+              </tr>
+            </tbody>
+          </table>
+          
+          <h4>ネットワーク操作コマンド</h4>
+          <div className={styles.codeBlock}>
+            <pre>
+              <code>
+                {`# ネットワーク一覧表示
+$ docker network ls
+
+# カスタムネットワーク作成
+$ docker network create my-network
+
+# ネットワークの詳細情報表示
+$ docker network inspect my-network
+
+# コンテナをネットワークに接続
+$ docker network connect my-network my-container
+
+# コンテナをネットワークから切断
+$ docker network disconnect my-network my-container
+
+# ネットワーク削除
+$ docker network rm my-network`}
+              </code>
+            </pre>
+          </div>
+          
+          <h4>Docker Composeでのネットワーク設定</h4>
+          <div className={styles.codeBlock}>
+            <pre>
+              <code>
+                {`version: '3.8'
+
+services:
+  web:
+    image: nginx
+    networks:
+      - frontend
+      
+  api:
+    image: node:alpine
+    networks:
+      - frontend
+      - backend
+      
+  db:
+    image: postgres
+    networks:
+      - backend
+      
+networks:
+  frontend:
+    driver: bridge
+  backend:
+    driver: bridge
+    internal: true  # 外部アクセス不可`}
+              </code>
+            </pre>
+          </div>
+          
+          <div className={styles.keyPoints}>
+            <h4>Docker ネットワークのポイント</h4>
+            <ul>
+              <li><strong>コンテナ名での通信</strong>: 同一ネットワーク内のコンテナは名前で相互通信可能</li>
+              <li><strong>ポート公開</strong>: 外部からのアクセスには <code>-p</code> オプションでポート公開が必要</li>
+              <li><strong>複数ネットワーク</strong>: コンテナは複数のネットワークに所属可能</li>
+              <li><strong>セキュリティ</strong>: 内部ネットワークを使って外部からの直接アクセスを制限</li>
+              <li><strong>DNS解決</strong>: Docker内部DNSでコンテナ名をIPに解決</li>
+            </ul>
+          </div>
+          
+          <div className={styles.dockerExample}>
+            <img 
+              src="https://docs.docker.com/engine/tutorials/networkingcontainers/images/working.png" 
+              alt="Docker Network Example" 
+              className={styles.dockerExampleImg}
+            />
+            <div className={styles.diagramCaption}>
+              Dockerコンテナネットワーク構成例（出典: Docker公式ドキュメント）
+            </div>
+          </div>
+        </div>
+      )
+    },
+    {
+      title: "Docker ボリューム",
+      development: "データ永続化",
+      content: (
+        <div className={styles.section}>
+          <h3>Docker ボリューム - データの永続化</h3>
+          <p>
+            Dockerコンテナ内のデータは、コンテナが削除されると失われます。
+            ボリュームを使用することで、データを永続化し、コンテナ間で共有することができます。
+          </p>
+          
+          <h4>ボリュームの種類</h4>
+          <table className={styles.compareTable}>
+            <thead>
+              <tr>
+                <th>種類</th>
+                <th>説明</th>
+                <th>ユースケース</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><strong>Dockerボリューム</strong></td>
+                <td>Dockerが管理するボリューム</td>
+                <td>データベース、設定ファイルなど</td>
+              </tr>
+              <tr>
+                <td><strong>バインドマウント</strong></td>
+                <td>ホスト上の特定パスをマウント</td>
+                <td>開発環境、設定ファイル</td>
+              </tr>
+              <tr>
+                <td><strong>tmpfs マウント</strong></td>
+                <td>メモリ上の一時ファイルシステム</td>
+                <td>一時データ、キャッシュ</td>
+              </tr>
+            </tbody>
+          </table>
+          
+          <h4>ボリューム操作コマンド</h4>
+          <div className={styles.codeBlock}>
+            <pre>
+              <code>
+                {`# ボリューム一覧表示
+$ docker volume ls
+
+# ボリューム作成
+$ docker volume create my-volume
+
+# ボリュームの詳細情報表示
+$ docker volume inspect my-volume
+
+# ボリュームの削除
+$ docker volume rm my-volume
+
+# 未使用ボリュームの一括削除
+$ docker volume prune`}
+              </code>
+            </pre>
+          </div>
+          
+          <h4>コンテナ起動時のボリューム指定</h4>
+          <div className={styles.codeBlock}>
+            <pre>
+              <code>
+                {`# Dockerボリュームの使用
+$ docker run -v my-volume:/data nginx
+
+# バインドマウントの使用
+$ docker run -v $(pwd)/host-dir:/container-dir nginx
+
+# 読み取り専用マウント
+$ docker run -v my-volume:/data:ro nginx`}
+              </code>
+            </pre>
+          </div>
+          
+          <h4>Docker Composeでのボリューム設定</h4>
+          <div className={styles.codeBlock}>
+            <pre>
+              <code>
+                {`version: '3.8'
+
+services:
+  db:
+    image: postgres
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+      
+  app:
+    build: .
+    volumes:
+      - .:/app  # バインドマウント
+      - /app/node_modules  # 匿名ボリューム
+      
+volumes:
+  postgres-data:  # 名前付きボリューム`}
+              </code>
+            </pre>
+          </div>
+          
+          <div className={styles.keyPoints}>
+            <h4>ボリューム利用のベストプラクティス</h4>
+            <ul>
+              <li><strong>開発環境</strong>: バインドマウントでソースコードを直接マウントし、ホットリロード可能に</li>
+              <li><strong>本番環境</strong>: Dockerボリュームを使用してデータを永続化</li>
+              <li><strong>ボリューム命名</strong>: 目的を明確にした命名規則を適用</li>
+              <li><strong>読み取り専用</strong>: 必要に応じて読み取り専用マウントを使用</li>
+              <li><strong>一時ディレクトリ</strong>: コンテナ内の一時ファイルにはtmpfsを検討</li>
+              <li><strong>バックアップ</strong>: 重要なデータボリュームは定期的にバックアップ</li>
+            </ul>
+          </div>
+          
+          <div className={styles.file}>
+            <div className={styles.fileName}>このプロジェクトのdocker-compose.yml（ボリューム部分）</div>
+            <pre>
+              <code>
+                {`volumes:
+  - .:/app:z,U    # ホストのカレントディレクトリをコンテナの/appにマウント
+  - /app/node_modules  # コンテナ内のnode_modulesを保護`}
+              </code>
+            </pre>
+          </div>
+          
+          <p>
+            <strong>特筆事項</strong>: <code>:z,U</code> フラグはSELinux環境でのファイル共有を有効にするものです。
+            また <code>/app/node_modules</code> のようなマウントは「匿名ボリューム」と呼ばれ、
+            バインドマウントで上書きされるのを防ぎます。
+          </p>
+        </div>
+      )
+    },
+    {
+      title: "開発環境でのDocker",
+      development: "開発ワークフロー",
+      content: (
+        <div className={styles.section}>
+          <h3>開発環境でのDocker活用</h3>
+          <p>
+            開発環境にDockerを導入することで、「環境差異」による問題を解消し、
+            開発からテスト、本番環境までの一貫したワークフローを実現します。
+          </p>
+          
+          <h4>開発環境のメリット</h4>
+          <ul>
+            <li><strong>環境の統一</strong>: 「自分のマシンでは動く」問題の解消</li>
+            <li><strong>迅速なセットアップ</strong>: 新メンバーが数分で開発環境を構築可能</li>
+            <li><strong>依存関係の分離</strong>: 異なるプロジェクト間の依存関係の競合を回避</li>
+            <li><strong>サービス分離</strong>: データベースなどの各サービスを独立して管理</li>
+            <li><strong>クリーンな環境</strong>: 使い終わったら削除可能</li>
+          </ul>
+          
+          <h4>開発用Dockerfile例</h4>
+          <div className={styles.codeBlock}>
+            <pre>
+              <code>
+                {`# 開発環境用Dockerfile
+FROM node:18-alpine
+
+# 開発ツールのインストール
+RUN apk add --no-cache git curl
+
+WORKDIR /app
+
+# パッケージ管理ファイルのみをコピー
+COPY package*.json ./
+
+# 依存関係をインストール
+RUN npm install
+
+# ソースコードはバインドマウントするので、コピー不要
+
+# ポート公開
+EXPOSE 3000
+
+# 開発サーバー起動（ホットリロード付き）
+CMD ["npm", "run", "dev"]`}
+              </code>
+            </pre>
+          </div>
+          
+          <h4>開発用Docker Compose例</h4>
+          <div className={styles.codeBlock}>
+            <pre>
+              <code>
+                {`version: '3.8'
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    ports:
+      - "3000:3000"
+    volumes:
+      - .:/app  # ソースコードをマウント
+      - /app/node_modules  # node_modulesを保護
+    environment:
+      - NODE_ENV=development
+    command: npm run dev  # ホットリロード付き開発サーバー
+      
+  db:
+    image: postgres:13
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-dev-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=devpassword
+      - POSTGRES_USER=devuser
+      - POSTGRES_DB=devdb
+      
+volumes:
+  postgres-dev-data:`}
+              </code>
+            </pre>
+          </div>
+          
+          <div className={styles.keyPoints}>
+            <h4>開発環境でのDockerのコツ</h4>
+            <ul>
+              <li><strong>ホットリロード</strong>: バインドマウントとホットリロード対応の開発サーバーを活用</li>
+              <li><strong>デバッグ</strong>: <code>docker-compose logs -f</code> でリアルタイムログ監視</li>
+              <li><strong>シェル</strong>: <code>docker-compose exec app sh</code> でコンテナ内シェルにアクセス</li>
+              <li><strong>キャッシュ</strong>: ビルド時間短縮のためDockerキャッシュを活用</li>
+              <li><strong>環境変数</strong>: <code>.env</code>ファイルで環境変数管理</li>
+              <li><strong>コンテナ名</strong>: わかりやすい名前でコンテナを管理</li>
+              <li><strong>ネットワーク分離</strong>: フロントエンド/バックエンド用の別ネットワークを検討</li>
+            </ul>
+          </div>
+          
+          <div className={styles.file}>
+            <div className={styles.fileName}>実際の開発ワークフロー例</div>
+            <pre>
+              <code>
+                {`# 1. 開発環境起動
+$ docker-compose up -d
+
+# 2. コードの変更（ホストマシン上で編集）
+# ホットリロードにより自動反映
+
+# 3. テスト実行
+$ docker-compose exec app npm test
+
+# 4. コンテナ内でコマンド実行
+$ docker-compose exec app npm install some-package
+
+# 5. ログ確認
+$ docker-compose logs -f
+
+# 6. 開発環境の停止
+$ docker-compose down  # データボリュームは保持
+
+# 7. 開発環境の完全削除
+$ docker-compose down -v  # ボリュームも削除`}
+              </code>
+            </pre>
+          </div>
+        </div>
+      )
+    },
+    {
+      title: "本番環境でのDocker",
+      development: "デプロイメント",
+      content: (
+        <div className={styles.section}>
+          <h3>本番環境でのDocker</h3>
+          <p>
+            Dockerは開発環境だけでなく、本番環境でも大きなメリットを提供します。
+            スケーラビリティ、移植性、一貫性のある展開が可能になります。
+          </p>
+          
+          <h4>本番用Dockerfile例</h4>
+          <div className={styles.codeBlock}>
+            <pre>
+              <code>
+                {`# 本番環境用マルチステージビルドDockerfile
+# ビルドステージ
+FROM node:18-alpine AS build
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+# 実行ステージ
+FROM node:18-alpine
+
+# セキュリティのため非rootユーザーを作成
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+WORKDIR /app
+
+# 本番環境の依存関係のみインストール
+COPY package*.json ./
+RUN npm ci --only=production
+
+# ビルド成果物をコピー
+COPY --from=build /app/.next ./.next
+COPY --from=build /app/public ./public
+COPY --from=build /app/next.config.js ./
+
+# 非rootユーザーに切り替え
+USER appuser
+
+EXPOSE 3000
+
+# ヘルスチェック
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+  CMD node -e "require('http').request('http://localhost:3000', {timeout:2000}).end()" || exit 1
+
+CMD ["npm", "start"]`}
+              </code>
+            </pre>
+          </div>
+          
+          <h4>本番デプロイの考慮事項</h4>
+          <table className={styles.compareTable}>
+            <thead>
+              <tr>
+                <th>項目</th>
+                <th>ベストプラクティス</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><strong>セキュリティ</strong></td>
+                <td>
+                  <ul>
+                    <li>非rootユーザーでコンテナを実行</li>
+                    <li>不要なパッケージを含めない</li>
+                    <li>イメージの脆弱性スキャンを実施</li>
+                    <li>シークレットを環境変数やシークレット管理ツールで管理</li>
+                  </ul>
+                </td>
+              </tr>
+              <tr>
+                <td><strong>パフォーマンス</strong></td>
+                <td>
+                  <ul>
+                    <li>イメージサイズを最小化（マルチステージビルド）</li>
+                    <li>適切なキャッシュ戦略</li>
+                    <li>リソース制限の設定</li>
+                  </ul>
+                </td>
+              </tr>
+              <tr>
+                <td><strong>可用性</strong></td>
+                <td>
+                  <ul>
+                    <li>ヘルスチェックの実装</li>
+                    <li>適切な再起動ポリシー</li>
+                    <li>複数インスタンスでの実行</li>
+                  </ul>
+                </td>
+              </tr>
+              <tr>
+                <td><strong>監視</strong></td>
+                <td>
+                  <ul>
+                    <li>ログ収集の設定</li>
+                    <li>メトリクスの収集</li>
+                    <li>アラートの設定</li>
+                  </ul>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          
+          <div className={styles.keyPoints}>
+            <h4>コンテナオーケストレーション</h4>
+            <p>本番環境では、複数コンテナの管理にオーケストレーションツールが必要です：</p>
+            <ul>
+              <li><strong>Kubernetes</strong>: 大規模環境向けの完全なコンテナオーケストレーションシステム</li>
+              <li><strong>Docker Swarm</strong>: Dockerに統合されたシンプルなオーケストレーションツール</li>
+              <li><strong>Amazon ECS/EKS</strong>: AWSのコンテナサービス</li>
+              <li><strong>Google GKE</strong>: GoogleのマネージドKubernetesサービス</li>
+              <li><strong>Azure AKS</strong>: MicrosoftのマネージドKubernetesサービス</li>
+            </ul>
+          </div>
+          
+          <h4>CI/CDパイプラインとの統合</h4>
+          <div className={styles.codeBlock}>
+            <pre>
+              <code>
+                {`# GitHub Actions ワークフロー例
+name: Docker CI/CD Pipeline
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        
+      - name: Login to Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest
+          
+      - name: Deploy to production
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USERNAME }}
+          key: ${{ secrets.SSH_KEY }}
+          script: |
+            docker pull ghcr.io/${{ github.repository }}:latest
+            docker-compose -f docker-compose.prod.yml up -d --force-recreate`}
+              </code>
+            </pre>
+          </div>
+        </div>
+      )
+    },
+    {
+      title: "Dockerベストプラクティス",
+      development: "最適化と改善",
+      content: (
+        <div className={styles.section}>
+          <h3>Dockerベストプラクティス総集編</h3>
+          <p>
+            これまで学んだDockerの知識を活かすための、ベストプラクティスと一般的なパターンをまとめます。
+            これらの実践は、効率的で保守しやすいDockerベースのアプリケーション開発に役立ちます。
+          </p>
+          
+          <h4>イメージ最適化</h4>
+          <ol>
+            <li><strong>適切なベースイメージ</strong>: 可能な限り軽量なベースイメージ（alpine等）を使用</li>
+            <li><strong>マルチステージビルド</strong>: ビルドツールと実行環境を分離し、最終イメージを小さく</li>
+            <li><strong>レイヤー最小化</strong>: RUN命令を集約してレイヤー数を減らす</li>
+            <li><strong>不要ファイル削除</strong>: キャッシュやテンポラリファイルを削除</li>
+            <li><strong>.dockerignore</strong>: 不要ファイルをビルドコンテキストから除外</li>
+          </ol>
+          
+          <div className={styles.codeBlock}>
+            <pre>
+              <code>
+                {`# 最適化されたDockerfile例
+FROM node:18-alpine AS build
+
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build && npm prune --production
+
+FROM node:18-alpine
+
+WORKDIR /app
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+
+# 1つのRUN命令で複数操作（レイヤー最小化）
+RUN addgroup -S appgroup && \\
+    adduser -S appuser -G appgroup && \\
+    chown -R appuser:appgroup /app
+
+USER appuser
+CMD ["node", "dist/server.js"]`}
+              </code>
+            </pre>
+          </div>
+          
+          <h4>セキュリティ強化</h4>
+          <ul>
+            <li><strong>最小権限原則</strong>: 非rootユーザーでコンテナを実行</li>
+            <li><strong>イメージスキャン</strong>: Trivy, Clair等でイメージの脆弱性をスキャン</li>
+            <li><strong>不変イメージ</strong>: イメージにタグではなくダイジェスト（SHA256）を使用</li>
+            <li><strong>シークレット管理</strong>: シークレットをDockerfileや環境変数に直接含めない</li>
+            <li><strong>読み取り専用ファイルシステム</strong>: <code>--read-only</code>フラグで実行</li>
+            <li><strong>ケイパビリティ制限</strong>: 必要最小限のケイパビリティのみ付与</li>
+          </ul>
+          
+          <h4>効率的な開発環境</h4>
+          <ul>
+            <li><strong>ホットリロード</strong>: バインドマウントとホットリロード対応の開発サーバー</li>
+            <li><strong>コード共有</strong>: 開発コードをボリュームでマウントし、変更を即時反映</li>
+            <li><strong>デバッグツール</strong>: 開発環境には適切なデバッグツールを含める</li>
+            <li><strong>開発/本番の分離</strong>: 異なるDockerfile（dev/prod）を用意</li>
+            <li><strong>依存関係キャッシュ</strong>: node_modules等をボリュームやビルドキャッシュで管理</li>
+          </ul>
+          
+          <div className={styles.keyPoints}>
+            <h4>コンテナライフサイクル管理</h4>
+            <ul>
+              <li><strong>自己修復性</strong>: ヘルスチェックと適切な再起動ポリシーを設定</li>
+              <li><strong>グレースフルシャットダウン</strong>: SIGTERMシグナルを適切に処理</li>
+              <li><strong>初期化スクリプト</strong>: コンテナ起動時の初期化作業を自動化</li>
+              <li><strong>サイドカーパターン</strong>: 関連機能を別コンテナで実装（ログ収集等）</li>
+              <li><strong>PID 1問題</strong>: シグナル処理のためにtiniやdumb-initを使用</li>
+            </ul>
+          </div>
+          
+          <h4>組織内Docker標準化</h4>
+          <ul>
+            <li><strong>ベースイメージの標準化</strong>: 組織内で共通のベースイメージを定義</li>
+            <li><strong>CI/CDパイプライン統合</strong>: 自動ビルド・テスト・デプロイを整備</li>
+            <li><strong>イメージレジストリ管理</strong>: プライベートレジストリの使用と管理</li>
+            <li><strong>ドキュメント</strong>: Dockerfileにコメントと使用方法を記載</li>
+            <li><strong>タグ戦略</strong>: バージョニングとタグ付けの規則を決定</li>
+            <li><strong>イメージライフサイクル</strong>: 古いイメージの定期的なクリーンアップ</li>
+          </ul>
+          
+          <div className={styles.keyPoints}>
+            <h4>パフォーマンスチューニング</h4>
+            <ul>
+              <li><strong>リソース制限</strong>: CPU/メモリ制限の適切な設定</li>
+              <li><strong>軽量化</strong>: イメージサイズの最小化</li>
+              <li><strong>キャッシュ戦略</strong>: ビルドキャッシュの効果的な活用</li>
+              <li><strong>ネットワークチューニング</strong>: 適切なネットワークドライバの選択</li>
+              <li><strong>ストレージドライバ</strong>: ワークロードに適したストレージドライバの選択</li>
+              <li><strong>水平スケーリング</strong>: 複数インスタンスでの負荷分散</li>
+            </ul>
+          </div>
+          
+          <div className={styles.dockerExample}>
+            <p>
+              Dockerは強力なツールですが、適切に使用するには経験と知識が必要です。
+              この講座で学んだ内容を実践し、継続的に学習することで、
+              Docker活用のスキルを磨いていきましょう。
+            </p>
+          </div>
+        </div>
+      )
+    }
+  ];
+
+  // 学習進捗と連携した次のステップ移動
+  const nextStep = () => {
+    if (currentStep < steps.length - 1) {
+      // 現在のステップを完了としてマーク
+      const currentStepData = steps[currentStep];
+      const topicId = getTopicIdFromTitle(currentStepData.title);
+      if (topicId) {
+        completeTopic(topicId);
+      }
+      
+      // 次のステップへ移動
+      setCurrentStep(currentStep + 1);
+      
+      // 対応するトピックを現在のトピックとして設定
+      const nextStepData = steps[currentStep + 1];
+      const nextTopicId = getTopicIdFromTitle(nextStepData.title);
+      if (nextTopicId) {
+        setCurrentTopic(nextTopicId);
+      }
+    }
+  };
+  
+  // トピックタイトルからトピックIDを取得するヘルパー関数
+  const getTopicIdFromTitle = (title: string): string | null => {
+    switch (title) {
+      case 'Dockerとは': return 'docker-intro';
+      case 'コンテナとVMの違い': return 'container-vs-vm';
+      case 'Docker基本コマンド': return 'docker-basic-commands';
+      case 'Dockerfile': return 'dockerfile';
+      case 'Docker Compose': return 'docker-compose';
+      case 'Docker ネットワーク': return 'docker-networks';
+      case 'Docker ボリューム': return 'docker-volumes';
+      case 'Dockerベストプラクティス': return 'docker-best-practices';
+      default: return null;
+    }
+  };
+
+  const prevStep = () => {
+    if (currentStep > 0) {
+      setCurrentStep(currentStep - 1);
+    }
+  };
+
+  return (
+    <motion.div 
+      className={styles.dockerGuide}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.5 }}
+    >
+      <motion.h2 
+        className={styles.title}
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.2, duration: 0.5 }}
+        data-version="v1.2.0"
+      >
+        Docker チュートリアル
+      </motion.h2>
+      
+      <div className={styles.progressBar}>
+        {steps.map((step, index) => (
+          <motion.div 
+            key={index}
+            className={`${styles.progressStep} ${index <= currentStep ? styles.completed : ''} ${index === currentStep ? styles.active : ''}`}
+            onClick={() => setCurrentStep(index)}
+            whileHover={{ scale: 1.05 }}
+            whileTap={{ scale: 0.95 }}
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.1 * index, duration: 0.3 }}
+          >
+            <span className={styles.stepNumber}>{index + 1}</span>
+            <span className={styles.stepTitle}>{step.title}</span>
+          </motion.div>
+        ))}
+      </div>
+      
+      <motion.div 
+        className={styles.developmentPhase}
+        initial={{ opacity: 0, x: -20 }}
+        animate={{ opacity: 1, x: 0 }}
+        transition={{ delay: 0.4, duration: 0.5 }}
+      >
+        <strong>学習テーマ：</strong> {steps[currentStep].development || "基礎概念"}
+        <div className={styles.userLevel}>
+          <span>学習レベル: {getDifficultyLevelName(progress.difficultyLevel)}</span>
+          {progress.badges.length > 0 && (
+            <div className={styles.badges}>
+              {progress.badges.map((badge, index) => (
+                <span key={index} className={styles.badge} title={getBadgeDescription(badge)}>
+                  {getBadgeEmoji(badge)}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+        <motion.div className={styles.viewToggle}>
+          <button 
+            className={`${styles.viewToggleButton} ${viewMode === 'text' ? styles.active : ''}`}
+            onClick={() => setViewMode('text')}
+          >
+            テキスト中心
+          </button>
+          <button 
+            className={`${styles.viewToggleButton} ${viewMode === 'graphic' ? styles.active : ''}`}
+            onClick={() => setViewMode('graphic')}
+          >
+            図解中心
+          </button>
+          <button 
+            className={`${styles.viewToggleButton} ${animationEnabled ? styles.active : ''}`}
+            onClick={() => setAnimationEnabled(!animationEnabled)}
+          >
+            {animationEnabled ? 'アニメーション ON' : 'アニメーション OFF'}
+          </button>
+          <select 
+            className={styles.languageSelector}
+            value={progress.language}
+            onChange={(e) => handleLanguageChange(e.target.value as 'ja' | 'en')}
+          >
+            <option value="ja">日本語</option>
+            <option value="en">English</option>
+          </select>
+        </motion.div>
+      </motion.div>
+      
+      <motion.div 
+        className={styles.content}
+        key={currentStep}
+        initial={animationEnabled ? { opacity: 0 } : false}
+        animate={animationEnabled ? { opacity: 1 } : false}
+        transition={animationEnabled ? { duration: 0.5 } : { duration: 0 }}
+      >
+        {/* 学習進捗に基づいたコンテンツの適応表示 */}
+        {steps[currentStep].content}
+        
+        {/* 学習進捗に基づくアダプティブコンテンツ */}
+        {currentStep > 0 && progress.completedTopics.includes(getTopicIdFromTitle(steps[currentStep-1].title) || '') && (
+          <div className={styles.adaptiveLearning}>
+            <div className={styles.previousKnowledge}>
+              <h4>前回の学習内容を活かして</h4>
+              <p>前回学習した{steps[currentStep-1].title}の知識を活かして、{steps[currentStep].title}をマスターしましょう。</p>
+            </div>
+          </div>
+        )}
+        
+        {/* 難易度レベルに応じた追加コンテンツ */}
+        {progress.difficultyLevel >= DifficultyLevel.INTERMEDIATE && currentStep >= 3 && (
+          <div className={styles.advancedContent}>
+            <h4>上級者向け追加情報</h4>
+            <p>あなたのレベルに合わせた上級者向けの追加情報です。</p>
+            <ul>
+              <li>最適化テクニック: マルチステージビルドや軽量イメージの活用</li>
+              <li>セキュリティベストプラクティス: 非rootユーザーの使用と権限制限</li>
+              <li>CI/CDパイプラインとの統合: GitHubアクションやJenkins連携</li>
+            </ul>
+          </div>
+        )}
+      </motion.div>
+      
+      <motion.div 
+        className={styles.navigation}
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.5, duration: 0.5 }}
+      >
+        <motion.button 
+          className={styles.navButton} 
+          onClick={prevStep} 
+          disabled={currentStep === 0}
+          whileHover={{ scale: 1.05 }}
+          whileTap={{ scale: 0.95 }}
+        >
+          前へ
+        </motion.button>
+        <motion.button 
+          className={styles.navButton} 
+          onClick={nextStep} 
+          disabled={currentStep === steps.length - 1}
+          whileHover={{ scale: 1.05 }}
+          whileTap={{ scale: 0.95 }}
+        >
+          次へ
+        </motion.button>
+      </motion.div>
+    </motion.div>
+  );
+};
+
+// 難易度レベル名を取得
+const getDifficultyLevelName = (level: DifficultyLevel): string => {
+  switch (level) {
+    case DifficultyLevel.BEGINNER:
+      return '初心者';
+    case DifficultyLevel.BASIC:
+      return '基本';
+    case DifficultyLevel.INTERMEDIATE:
+      return '中級';
+    case DifficultyLevel.ADVANCED:
+      return '上級';
+    default:
+      return '不明';
+  }
+};
+
+// バッジの説明を取得
+const getBadgeDescription = (badge: string): string => {
+  switch (badge) {
+    case 'beginner-scholar':
+      return 'Docker基礎知識マスター';
+    case 'command-novice':
+      return 'コマンド達成者';
+    case 'docker-architect':
+      return 'Docker構成設計者';
+    default:
+      return 'バッジ';
+  }
+};
+
+// バッジの絵文字を取得
+const getBadgeEmoji = (badge: string): string => {
+  switch (badge) {
+    case 'beginner-scholar':
+      return '🎓';
+    case 'command-novice':
+      return '⌨️';
+    case 'docker-architect':
+      return '🏗️';
+    default:
+      return '🏅';
+  }
+};
+
+export default DockerGuide;

--- a/container/claudecode/studyGIt/src/components/DockerLearningContext.tsx
+++ b/container/claudecode/studyGIt/src/components/DockerLearningContext.tsx
@@ -1,0 +1,419 @@
+"use client";
+
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { DifficultyLevel } from './DockerSimulator';
+
+// 学習トピック
+export interface LearningTopic {
+  id: string;
+  title: string;
+  description: string;
+  difficultyLevel: DifficultyLevel;
+  isCompleted: boolean;
+  isLocked: boolean;
+  requiredTopics?: string[];  // この前に完了すべきトピックID
+}
+
+// 学習進行状態
+export interface LearningProgress {
+  userId: string;
+  completedTopics: string[];
+  lastStudiedTopic: string | null;
+  difficultyLevel: DifficultyLevel;
+  completedChallenges: string[];
+  badges: string[];
+  language: 'ja' | 'en';
+}
+
+// コンテキスト型定義
+interface DockerLearningContextType {
+  // 学習トピックとステート
+  topics: LearningTopic[];
+  currentTopicId: string | null;
+  progress: LearningProgress;
+  
+  // 教育モード
+  educationalMode: boolean;
+  educationalTipsEnabled: boolean;
+
+  // メソッド
+  setCurrentTopic: (topicId: string) => void;
+  completeCurrentTopic: () => void;
+  completeTopic: (topicId: string) => void;
+  completeChallenge: (challengeId: string) => void;
+  getNextRecommendedTopic: () => string | null;
+  setDifficultyLevel: (level: DifficultyLevel) => void;
+  toggleEducationalMode: () => void;
+  toggleEducationalTips: () => void;
+  setLanguage: (language: 'ja' | 'en') => void;
+  resetProgress: () => void;
+}
+
+// デフォルトコンテキスト値
+const defaultContext: DockerLearningContextType = {
+  topics: [],
+  currentTopicId: null,
+  progress: {
+    userId: 'guest',
+    completedTopics: [],
+    lastStudiedTopic: null,
+    difficultyLevel: DifficultyLevel.BEGINNER,
+    completedChallenges: [],
+    badges: [],
+    language: 'ja'
+  },
+  educationalMode: true,
+  educationalTipsEnabled: true,
+  
+  setCurrentTopic: () => {},
+  completeCurrentTopic: () => {},
+  completeTopic: () => {},
+  completeChallenge: () => {},
+  getNextRecommendedTopic: () => null,
+  setDifficultyLevel: () => {},
+  toggleEducationalMode: () => {},
+  toggleEducationalTips: () => {},
+  setLanguage: () => {},
+  resetProgress: () => {}
+};
+
+// コンテキスト作成
+const DockerLearningContext = createContext<DockerLearningContextType>(defaultContext);
+
+// 初期トピックデータ
+const initialTopics: LearningTopic[] = [
+  // 初心者レベル (Beginner)
+  {
+    id: 'docker-intro',
+    title: 'Dockerとは何か',
+    description: 'Dockerの基本概念と仮想化との違い',
+    difficultyLevel: DifficultyLevel.BEGINNER,
+    isCompleted: false,
+    isLocked: false
+  },
+  {
+    id: 'container-vs-vm',
+    title: 'コンテナとVMの違い',
+    description: 'コンテナと仮想マシンの違いと特徴',
+    difficultyLevel: DifficultyLevel.BEGINNER,
+    isCompleted: false,
+    isLocked: false,
+    requiredTopics: ['docker-intro']
+  },
+  {
+    id: 'docker-basic-commands',
+    title: 'Docker基本コマンド',
+    description: 'Dockerの基本的なコマンドと使い方',
+    difficultyLevel: DifficultyLevel.BEGINNER,
+    isCompleted: false,
+    isLocked: false,
+    requiredTopics: ['docker-intro']
+  },
+
+  // 基本レベル (Basic)
+  {
+    id: 'dockerfile',
+    title: 'Dockerfile作成',
+    description: 'Dockerfileの書き方と構成方法',
+    difficultyLevel: DifficultyLevel.BASIC,
+    isCompleted: false,
+    isLocked: true,
+    requiredTopics: ['docker-basic-commands']
+  },
+  {
+    id: 'docker-images',
+    title: 'Dockerイメージ管理',
+    description: 'イメージの作成、管理、配布方法',
+    difficultyLevel: DifficultyLevel.BASIC,
+    isCompleted: false,
+    isLocked: true,
+    requiredTopics: ['dockerfile']
+  },
+
+  // 中級レベル (Intermediate)
+  {
+    id: 'docker-compose',
+    title: 'Docker Compose',
+    description: '複数コンテナの設定と管理',
+    difficultyLevel: DifficultyLevel.INTERMEDIATE,
+    isCompleted: false,
+    isLocked: true,
+    requiredTopics: ['docker-images']
+  },
+  {
+    id: 'docker-networks',
+    title: 'Dockerネットワーク',
+    description: 'コンテナ間通信とネットワーク設定',
+    difficultyLevel: DifficultyLevel.INTERMEDIATE,
+    isCompleted: false,
+    isLocked: true,
+    requiredTopics: ['docker-compose']
+  },
+  {
+    id: 'docker-volumes',
+    title: 'Dockerボリューム',
+    description: 'データの永続化と共有',
+    difficultyLevel: DifficultyLevel.INTERMEDIATE,
+    isCompleted: false,
+    isLocked: true,
+    requiredTopics: ['docker-compose']
+  },
+
+  // 上級レベル (Advanced)
+  {
+    id: 'docker-best-practices',
+    title: 'Dockerベストプラクティス',
+    description: 'Docker利用の最適化とセキュリティ',
+    difficultyLevel: DifficultyLevel.ADVANCED,
+    isCompleted: false,
+    isLocked: true,
+    requiredTopics: ['docker-networks', 'docker-volumes']
+  }
+];
+
+// 初期進行状態
+const initialProgress: LearningProgress = {
+  userId: 'guest',
+  completedTopics: [],
+  lastStudiedTopic: null,
+  difficultyLevel: DifficultyLevel.BEGINNER,
+  completedChallenges: [],
+  badges: [],
+  language: 'ja'
+};
+
+// プロバイダーコンポーネント
+export const DockerLearningProvider: React.FC<{children: React.ReactNode}> = ({ children }) => {
+  // 状態管理
+  const [topics, setTopics] = useState<LearningTopic[]>(initialTopics);
+  const [progress, setProgress] = useState<LearningProgress>(initialProgress);
+  const [currentTopicId, setCurrentTopicId] = useState<string | null>('docker-intro');
+  const [educationalMode, setEducationalMode] = useState(true);
+  const [educationalTipsEnabled, setEducationalTipsEnabled] = useState(true);
+  
+  // LocalStorageからの状態復元
+  useEffect(() => {
+    const savedProgress = localStorage.getItem('docker-learning-progress');
+    if (savedProgress) {
+      try {
+        const parsedProgress = JSON.parse(savedProgress);
+        setProgress(parsedProgress);
+        
+        // トピックのロック状態を更新
+        updateTopicsLockStatus(parsedProgress.completedTopics);
+      } catch (error) {
+        console.error('Failed to parse saved progress', error);
+      }
+    }
+    
+    // 学習設定の復元
+    const savedEducationalMode = localStorage.getItem('docker-educational-mode');
+    if (savedEducationalMode) {
+      setEducationalMode(savedEducationalMode === 'true');
+    }
+    
+    const savedTipsEnabled = localStorage.getItem('docker-tips-enabled');
+    if (savedTipsEnabled) {
+      setEducationalTipsEnabled(savedTipsEnabled === 'true');
+    }
+  }, []);
+  
+  // 状態変更時にLocalStorageに保存
+  useEffect(() => {
+    localStorage.setItem('docker-learning-progress', JSON.stringify(progress));
+  }, [progress]);
+  
+  useEffect(() => {
+    localStorage.setItem('docker-educational-mode', educationalMode.toString());
+  }, [educationalMode]);
+  
+  useEffect(() => {
+    localStorage.setItem('docker-tips-enabled', educationalTipsEnabled.toString());
+  }, [educationalTipsEnabled]);
+  
+  // トピックのロック状態を更新
+  const updateTopicsLockStatus = (completedTopicIds: string[]) => {
+    setTopics(prevTopics => {
+      return prevTopics.map(topic => {
+        // 基本的にレベルに基づいたロック状態を設定
+        let isLocked = topic.difficultyLevel > progress.difficultyLevel;
+        
+        // 必要なトピックが完了していない場合はロック
+        if (topic.requiredTopics && topic.requiredTopics.length > 0) {
+          const allRequiredCompleted = topic.requiredTopics.every(
+            requiredId => completedTopicIds.includes(requiredId)
+          );
+          isLocked = isLocked || !allRequiredCompleted;
+        }
+        
+        return {
+          ...topic,
+          isCompleted: completedTopicIds.includes(topic.id),
+          isLocked: isLocked
+        };
+      });
+    });
+  };
+  
+  // 現在のトピックを設定
+  const setCurrentTopic = (topicId: string) => {
+    const topic = topics.find(t => t.id === topicId);
+    if (topic && !topic.isLocked) {
+      setCurrentTopicId(topicId);
+      setProgress(prev => ({
+        ...prev,
+        lastStudiedTopic: topicId
+      }));
+    }
+  };
+  
+  // 現在のトピックを完了としてマーク
+  const completeCurrentTopic = () => {
+    if (currentTopicId) {
+      completeTopic(currentTopicId);
+    }
+  };
+  
+  // 指定したトピックを完了としてマーク
+  const completeTopic = (topicId: string) => {
+    if (!progress.completedTopics.includes(topicId)) {
+      const newCompletedTopics = [...progress.completedTopics, topicId];
+      
+      setProgress(prev => ({
+        ...prev,
+        completedTopics: newCompletedTopics
+      }));
+      
+      // トピックのロック状態を更新
+      updateTopicsLockStatus(newCompletedTopics);
+      
+      // バッジの更新
+      checkAndUpdateBadges(newCompletedTopics);
+    }
+  };
+  
+  // チャレンジを完了としてマーク
+  const completeChallenge = (challengeId: string) => {
+    if (!progress.completedChallenges.includes(challengeId)) {
+      const newCompletedChallenges = [...progress.completedChallenges, challengeId];
+      
+      setProgress(prev => ({
+        ...prev,
+        completedChallenges: newCompletedChallenges
+      }));
+      
+      // バッジの更新
+      checkAndUpdateBadges(progress.completedTopics, newCompletedChallenges);
+    }
+  };
+  
+  // バッジの条件チェックと更新
+  const checkAndUpdateBadges = (completedTopics: string[] = progress.completedTopics, completedChallenges: string[] = progress.completedChallenges) => {
+    const newBadges = [...progress.badges];
+    
+    // 初心者レベルのバッジ
+    if (completedTopics.includes('docker-intro') && 
+        completedTopics.includes('container-vs-vm') && 
+        !newBadges.includes('beginner-scholar')) {
+      newBadges.push('beginner-scholar');
+    }
+    
+    // コマンド達成バッジ
+    if (completedChallenges.length >= 3 && !newBadges.includes('command-novice')) {
+      newBadges.push('command-novice');
+    }
+    
+    // 中級者バッジ
+    if (completedTopics.includes('docker-compose') && 
+        completedTopics.includes('docker-networks') &&
+        !newBadges.includes('docker-architect')) {
+      newBadges.push('docker-architect');
+    }
+    
+    // バッジが増えた場合のみ更新
+    if (newBadges.length > progress.badges.length) {
+      setProgress(prev => ({
+        ...prev,
+        badges: newBadges
+      }));
+    }
+  };
+  
+  // 次に推奨するトピックを取得
+  const getNextRecommendedTopic = (): string | null => {
+    // まだ完了していないロックされていないトピックを探す
+    const nextTopic = topics.find(topic => 
+      !topic.isCompleted && !topic.isLocked && 
+      topic.difficultyLevel <= progress.difficultyLevel
+    );
+    
+    return nextTopic ? nextTopic.id : null;
+  };
+  
+  // 難易度レベル設定
+  const setDifficultyLevel = (level: DifficultyLevel) => {
+    setProgress(prev => ({
+      ...prev,
+      difficultyLevel: level
+    }));
+    
+    // トピックのロック状態を更新
+    updateTopicsLockStatus(progress.completedTopics);
+  };
+  
+  // 教育モード切り替え
+  const toggleEducationalMode = () => {
+    setEducationalMode(prev => !prev);
+  };
+  
+  // 教育用ヒント表示切り替え
+  const toggleEducationalTips = () => {
+    setEducationalTipsEnabled(prev => !prev);
+  };
+  
+  // 言語設定
+  const setLanguage = (language: 'ja' | 'en') => {
+    setProgress(prev => ({
+      ...prev,
+      language
+    }));
+  };
+  
+  // 進捗リセット
+  const resetProgress = () => {
+    setProgress(initialProgress);
+    updateTopicsLockStatus([]);
+    setCurrentTopicId('docker-intro');
+  };
+  
+  // コンテキスト値
+  const contextValue: DockerLearningContextType = {
+    topics,
+    currentTopicId,
+    progress,
+    educationalMode,
+    educationalTipsEnabled,
+    
+    setCurrentTopic,
+    completeCurrentTopic,
+    completeTopic,
+    completeChallenge,
+    getNextRecommendedTopic,
+    setDifficultyLevel,
+    toggleEducationalMode,
+    toggleEducationalTips,
+    setLanguage,
+    resetProgress
+  };
+  
+  return (
+    <DockerLearningContext.Provider value={contextValue}>
+      {children}
+    </DockerLearningContext.Provider>
+  );
+};
+
+// カスタムフック
+export const useDockerLearning = () => useContext(DockerLearningContext);
+
+export default DockerLearningContext;

--- a/container/claudecode/studyGIt/src/components/DockerSimulator.ts
+++ b/container/claudecode/studyGIt/src/components/DockerSimulator.ts
@@ -1,0 +1,1263 @@
+/**
+ * DockerSimulator.ts
+ * Docker操作のシミュレーションエンジン
+ */
+
+// コンテナの状態タイプ
+export type ContainerStatus = 'running' | 'exited' | 'created' | 'paused';
+
+// ポートマッピングインターフェース
+export interface PortMapping {
+  host: string;
+  container: string;
+}
+
+// ボリュームマッピングインターフェース
+export interface VolumeMapping {
+  host: string;
+  container: string;
+}
+
+// コンテナインターフェース
+export interface Container {
+  id: string;
+  name: string;
+  image: string;
+  status: ContainerStatus;
+  ports: PortMapping[];
+  volumes: VolumeMapping[];
+  networks: string[];
+  env?: Record<string, string>;
+  command?: string;
+  created: string;
+}
+
+// イメージインターフェース
+export interface DockerImage {
+  id: string;
+  repository: string;
+  tag: string;
+  size: string;
+  created: string;
+}
+
+// Dockerfileコマンドインターフェース
+export interface DockerfileCommand {
+  instruction: string;
+  arguments: string;
+  comment?: string;
+}
+
+// Dockerfileインターフェース
+export interface Dockerfile {
+  path: string;
+  commands: DockerfileCommand[];
+}
+
+// Docker状態インターフェース
+export interface DockerState {
+  containers: Container[];
+  images: string[];
+  volumes: string[];
+  networks: string[];
+}
+
+// 難易度レベル
+export enum DifficultyLevel {
+  BEGINNER = 1,
+  BASIC = 2,
+  INTERMEDIATE = 3,
+  ADVANCED = 4
+}
+
+// コマンド実行結果インターフェース
+export interface CommandResult {
+  success: boolean;
+  message: string;
+  data?: any;
+}
+
+// Docker Compose サービス定義
+export interface DockerComposeService {
+  image?: string;
+  build?: {
+    context: string;
+    dockerfile?: string;
+  };
+  ports?: string[];
+  volumes?: string[];
+  environment?: Record<string, string> | string[];
+  depends_on?: string[];
+  networks?: string[];
+}
+
+// Docker Compose 設定
+export interface DockerComposeConfig {
+  version: string;
+  services: Record<string, DockerComposeService>;
+  networks?: Record<string, any>;
+  volumes?: Record<string, any>;
+}
+
+/**
+ * DockerSimulator クラス
+ * Docker コマンドのシミュレーションを行う
+ */
+export class DockerSimulator {
+  private state: DockerState;
+  private level: DifficultyLevel;
+  private dockerfiles: Record<string, Dockerfile>;
+  private composeConfigs: Record<string, DockerComposeConfig>;
+
+  /**
+   * コンストラクタ
+   * @param initialState 初期Docker状態（オプション）
+   * @param level 難易度レベル（デフォルト：初心者）
+   */
+  constructor(initialState?: DockerState, level: DifficultyLevel = DifficultyLevel.BEGINNER) {
+    this.state = initialState || {
+      containers: [],
+      images: [],
+      volumes: [],
+      networks: ['bridge', 'host', 'none']
+    };
+    this.level = level;
+    this.dockerfiles = {};
+    this.composeConfigs = {};
+  }
+
+  /**
+   * コマンドの実行
+   * @param command 実行するコマンド文字列
+   * @returns コマンド実行結果
+   */
+  executeCommand(command: string): CommandResult {
+    // コマンドを解析
+    const parts = command.split(' ').filter(part => part.trim() !== '');
+    
+    // 'docker'で始まるコマンドのみ処理
+    if (parts[0] !== 'docker') {
+      return {
+        success: false,
+        message: 'Unknown command. Use docker commands.'
+      };
+    }
+
+    const subCommand = parts[1];
+
+    // 現在の難易度レベルで利用可能なコマンドかチェック
+    if (!this.isCommandAvailable(subCommand)) {
+      return {
+        success: false,
+        message: `Command 'docker ${subCommand}' is not available at your current level. Level up to unlock this command.`
+      };
+    }
+
+    // 各種dockerコマンドのシミュレーション実行
+    switch (subCommand) {
+      case 'ps':
+        return this.handleDockerPs(parts.slice(2));
+      case 'run':
+        return this.handleDockerRun(parts.slice(2));
+      case 'images':
+        return this.handleDockerImages();
+      case 'pull':
+        return this.handleDockerPull(parts.slice(2));
+      case 'stop':
+        return this.handleDockerStop(parts.slice(2));
+      case 'start':
+        return this.handleDockerStart(parts.slice(2));
+      case 'rm':
+        return this.handleDockerRm(parts.slice(2));
+      case 'rmi':
+        return this.handleDockerRmi(parts.slice(2));
+      case 'build':
+        return this.handleDockerBuild(parts.slice(2));
+      case 'network':
+        return this.handleDockerNetwork(parts.slice(2));
+      case 'volume':
+        return this.handleDockerVolume(parts.slice(2));
+      case 'logs':
+        return this.handleDockerLogs(parts.slice(2));
+      case 'exec':
+        return this.handleDockerExec(parts.slice(2));
+      case 'compose':
+        return this.handleDockerCompose(parts.slice(2));
+      case 'help':
+        return this.handleDockerHelp();
+      default:
+        return {
+          success: false,
+          message: `Unknown docker command: ${subCommand}`
+        };
+    }
+  }
+
+  /**
+   * 特定のコマンドが現在の難易度レベルで利用可能かチェック
+   * @param command コマンド名
+   * @returns 利用可能な場合 true
+   */
+  private isCommandAvailable(command: string): boolean {
+    // レベルに応じたコマンド制限
+    const commandLevels: Record<string, DifficultyLevel> = {
+      // BEGINNER レベル (Level 1) - 基本的なコンテナ管理
+      'ps': DifficultyLevel.BEGINNER,
+      'run': DifficultyLevel.BEGINNER,
+      'images': DifficultyLevel.BEGINNER,
+      'stop': DifficultyLevel.BEGINNER,
+      'start': DifficultyLevel.BEGINNER,
+      'help': DifficultyLevel.BEGINNER,
+
+      // BASIC レベル (Level 2) - イメージ管理
+      'pull': DifficultyLevel.BASIC,
+      'rm': DifficultyLevel.BASIC,
+      'rmi': DifficultyLevel.BASIC,
+      'logs': DifficultyLevel.BASIC,
+
+      // INTERMEDIATE レベル (Level 3) - ネットワークとボリューム
+      'build': DifficultyLevel.INTERMEDIATE,
+      'network': DifficultyLevel.INTERMEDIATE,
+      'volume': DifficultyLevel.INTERMEDIATE,
+      'exec': DifficultyLevel.INTERMEDIATE,
+
+      // ADVANCED レベル (Level 4) - Docker-compose
+      'compose': DifficultyLevel.ADVANCED
+    };
+
+    // コマンドが存在し、現在のレベル以下である場合に利用可能
+    return commandLevels[command] !== undefined && commandLevels[command] <= this.level;
+  }
+
+  /**
+   * 難易度レベルの変更
+   * @param level 新しい難易度レベル
+   */
+  setDifficultyLevel(level: DifficultyLevel): void {
+    this.level = level;
+  }
+
+  /**
+   * 現在の難易度レベルの取得
+   * @returns 現在の難易度レベル
+   */
+  getDifficultyLevel(): DifficultyLevel {
+    return this.level;
+  }
+
+  /**
+   * 現在のDockerの状態を取得
+   * @returns Docker状態オブジェクト
+   */
+  getState(): DockerState {
+    return {...this.state};
+  }
+
+  /**
+   * Docker状態の更新
+   * @param newState 新しいDocker状態
+   */
+  setState(newState: DockerState): void {
+    this.state = {...newState};
+  }
+
+  /**
+   * Dockerfileの追加
+   * @param path Dockerfileのパス
+   * @param dockerfile Dockerfileの内容
+   */
+  addDockerfile(path: string, dockerfile: Dockerfile): void {
+    this.dockerfiles[path] = dockerfile;
+  }
+
+  /**
+   * Docker Compose設定の追加
+   * @param path docker-compose.ymlのパス
+   * @param config Compose設定
+   */
+  addComposeConfig(path: string, config: DockerComposeConfig): void {
+    this.composeConfigs[path] = config;
+  }
+
+  // 以下、各種Dockerコマンドハンドラーのスケルトン実装
+  // 実際の実装では、もっと詳細なコマンドオプション解析と処理が必要
+
+  /**
+   * 'docker ps'コマンド処理
+   */
+  private handleDockerPs(args: string[]): CommandResult {
+    // オプション解析（-a フラグの検出）
+    const showAll = args.includes('-a') || args.includes('--all');
+    
+    // フィルターするコンテナ
+    let containers = this.state.containers;
+    if (!showAll) {
+      containers = containers.filter(container => container.status === 'running');
+    }
+    
+    return {
+      success: true,
+      message: this.formatPsOutput(containers),
+      data: containers
+    };
+  }
+
+  /**
+   * 'docker run'コマンド処理
+   */
+  private handleDockerRun(args: string[]): CommandResult {
+    // シンプルな実装のため、オプション解析は簡略化
+    if (args.length === 0) {
+      return {
+        success: false,
+        message: 'Usage: docker run [OPTIONS] IMAGE [COMMAND] [ARG...]'
+      };
+    }
+
+    // イメージ名の取得（オプションを除去して最初の引数を使用）
+    let imageName = '';
+    let detached = false;
+    let name = '';
+    let ports: PortMapping[] = [];
+    let volumes: VolumeMapping[] = [];
+    let command = '';
+    let networks: string[] = ['bridge'];
+
+    // 非常に単純なオプション解析
+    for (let i = 0; i < args.length; i++) {
+      if (args[i] === '-d' || args[i] === '--detach') {
+        detached = true;
+      } else if (args[i] === '--name' && i + 1 < args.length) {
+        name = args[i + 1];
+        i++;
+      } else if (args[i] === '-p' && i + 1 < args.length) {
+        const portMapping = args[i + 1].split(':');
+        if (portMapping.length === 2) {
+          ports.push({
+            host: portMapping[0],
+            container: portMapping[1]
+          });
+        }
+        i++;
+      } else if (args[i] === '-v' && i + 1 < args.length) {
+        const volumeMapping = args[i + 1].split(':');
+        if (volumeMapping.length === 2) {
+          volumes.push({
+            host: volumeMapping[0],
+            container: volumeMapping[1]
+          });
+        }
+        i++;
+      } else if (args[i] === '--network' && i + 1 < args.length) {
+        networks = [args[i + 1]];
+        i++;
+      } else if (!imageName) {
+        imageName = args[i];
+      } else {
+        // イメージ名以降はコマンドと解釈
+        command = args.slice(i).join(' ');
+        break;
+      }
+    }
+
+    // イメージが存在するかチェック
+    if (!this.state.images.includes(imageName)) {
+      return {
+        success: false,
+        message: `Unable to find image '${imageName}' locally`
+      };
+    }
+
+    // ネットワークが存在するかチェック
+    if (!this.state.networks.includes(networks[0])) {
+      return {
+        success: false,
+        message: `Error: No such network: ${networks[0]}`
+      };
+    }
+
+    // 一意のコンテナIDを生成
+    const id = `container-${Date.now()}-${Math.floor(Math.random() * 10000)}`;
+    
+    // 名前が指定されていない場合はランダムな名前を生成
+    if (!name) {
+      // 形容詞と名詞のランダムな組み合わせ（Docker風）
+      const adjectives = ['happy', 'jolly', 'dreamy', 'sad', 'angry', 'pensive', 'focused'];
+      const nouns = ['einstein', 'newton', 'tesla', 'bohr', 'feynman', 'curie', 'darwin'];
+      
+      const adjective = adjectives[Math.floor(Math.random() * adjectives.length)];
+      const noun = nouns[Math.floor(Math.random() * nouns.length)];
+      
+      name = `${adjective}_${noun}`;
+    }
+    
+    // 新しいコンテナを作成
+    const newContainer: Container = {
+      id,
+      name,
+      image: imageName,
+      status: 'running',
+      ports,
+      volumes,
+      networks,
+      command,
+      created: new Date().toISOString()
+    };
+    
+    // コンテナをステートに追加
+    this.state.containers.push(newContainer);
+    
+    // 開始メッセージの生成
+    const message = detached 
+      ? `${id.substring(0, 12)}` 
+      : `コンテナID: ${id}\n起動成功: ${name}\nステータス: running\nイメージ: ${imageName}${command ? `\nコマンド: ${command}` : ''}`;
+    
+    return {
+      success: true,
+      message,
+      data: newContainer
+    };
+  }
+
+  /**
+   * 'docker images'コマンド処理
+   */
+  private handleDockerImages(): CommandResult {
+    const message = this.formatImagesOutput();
+    
+    return {
+      success: true,
+      message,
+      data: this.state.images
+    };
+  }
+
+  /**
+   * 'docker pull'コマンド処理
+   */
+  private handleDockerPull(args: string[]): CommandResult {
+    if (args.length === 0) {
+      return {
+        success: false,
+        message: 'Usage: docker pull [OPTIONS] NAME[:TAG|@DIGEST]'
+      };
+    }
+
+    const image = args[0];
+    
+    // イメージが既に存在する場合
+    if (this.state.images.includes(image)) {
+      return {
+        success: true,
+        message: `Using cache\n${image}: Already exists`
+      };
+    }
+    
+    // 新しいイメージを追加
+    this.state.images.push(image);
+    
+    return {
+      success: true,
+      message: `Pulling from ${image}\nStatus: Downloaded newer image for ${image}`
+    };
+  }
+
+  /**
+   * 'docker stop'コマンド処理
+   */
+  private handleDockerStop(args: string[]): CommandResult {
+    if (args.length === 0) {
+      return {
+        success: false,
+        message: 'Usage: docker stop [OPTIONS] CONTAINER [CONTAINER...]'
+      };
+    }
+
+    const containerId = args[0];
+    const containerIndex = this.state.containers.findIndex(
+      container => container.id === containerId || container.id.startsWith(containerId) || container.name === containerId
+    );
+    
+    if (containerIndex === -1) {
+      return {
+        success: false,
+        message: `Error: No such container: ${containerId}`
+      };
+    }
+    
+    // コンテナの状態を更新
+    if (this.state.containers[containerIndex].status === 'running') {
+      this.state.containers[containerIndex].status = 'exited';
+      
+      return {
+        success: true,
+        message: containerId
+      };
+    } else {
+      return {
+        success: false,
+        message: `Error: Container ${containerId} is not running`
+      };
+    }
+  }
+
+  /**
+   * 'docker start'コマンド処理
+   */
+  private handleDockerStart(args: string[]): CommandResult {
+    if (args.length === 0) {
+      return {
+        success: false,
+        message: 'Usage: docker start [OPTIONS] CONTAINER [CONTAINER...]'
+      };
+    }
+
+    const containerId = args[0];
+    const containerIndex = this.state.containers.findIndex(
+      container => container.id === containerId || container.id.startsWith(containerId) || container.name === containerId
+    );
+    
+    if (containerIndex === -1) {
+      return {
+        success: false,
+        message: `Error: No such container: ${containerId}`
+      };
+    }
+    
+    // コンテナの状態を更新
+    if (this.state.containers[containerIndex].status !== 'running') {
+      this.state.containers[containerIndex].status = 'running';
+      
+      return {
+        success: true,
+        message: containerId
+      };
+    } else {
+      return {
+        success: false,
+        message: `Error: Container ${containerId} is already running`
+      };
+    }
+  }
+
+  /**
+   * 'docker rm'コマンド処理
+   */
+  private handleDockerRm(args: string[]): CommandResult {
+    if (args.length === 0) {
+      return {
+        success: false,
+        message: 'Usage: docker rm [OPTIONS] CONTAINER [CONTAINER...]'
+      };
+    }
+
+    const containerId = args[0];
+    const forceRemove = args.includes('-f') || args.includes('--force');
+    
+    const containerIndex = this.state.containers.findIndex(
+      container => container.id === containerId || container.id.startsWith(containerId) || container.name === containerId
+    );
+    
+    if (containerIndex === -1) {
+      return {
+        success: false,
+        message: `Error: No such container: ${containerId}`
+      };
+    }
+    
+    // 実行中のコンテナは削除できない（-fオプションがある場合を除く）
+    if (this.state.containers[containerIndex].status === 'running' && !forceRemove) {
+      return {
+        success: false,
+        message: `Error: You cannot remove a running container ${containerId}. Stop the container before attempting removal or use force`
+      };
+    }
+    
+    // コンテナを削除
+    const removedContainer = this.state.containers.splice(containerIndex, 1)[0];
+    
+    return {
+      success: true,
+      message: removedContainer.id
+    };
+  }
+
+  /**
+   * 'docker rmi'コマンド処理
+   */
+  private handleDockerRmi(args: string[]): CommandResult {
+    if (args.length === 0) {
+      return {
+        success: false,
+        message: 'Usage: docker rmi [OPTIONS] IMAGE [IMAGE...]'
+      };
+    }
+
+    const imageName = args[0];
+    const forceRemove = args.includes('-f') || args.includes('--force');
+    
+    const imageIndex = this.state.images.indexOf(imageName);
+    if (imageIndex === -1) {
+      return {
+        success: false,
+        message: `Error: No such image: ${imageName}`
+      };
+    }
+    
+    // このイメージを使用しているコンテナをチェック
+    const usedByContainers = this.state.containers.filter(container => container.image === imageName);
+    if (usedByContainers.length > 0 && !forceRemove) {
+      const containerIds = usedByContainers.map(container => container.id.substring(0, 12)).join(", ");
+      return {
+        success: false,
+        message: `Error: conflict: unable to remove repository reference ${imageName} (must force) - container ${containerIds} is using its referenced image`
+      };
+    }
+    
+    // イメージを削除
+    this.state.images.splice(imageIndex, 1);
+    
+    // 強制削除の場合は関連するコンテナも削除
+    if (forceRemove) {
+      this.state.containers = this.state.containers.filter(container => container.image !== imageName);
+    }
+    
+    return {
+      success: true,
+      message: `Untagged: ${imageName}\nDeleted: ${imageName}`
+    };
+  }
+
+  /**
+   * 'docker build'コマンド処理
+   */
+  private handleDockerBuild(args: string[]): CommandResult {
+    // 実際の実装では、Dockerfileを解析してイメージをビルドする
+    let tagName = 'latest';
+    let contextPath = '.';
+    
+    for (let i = 0; i < args.length; i++) {
+      if ((args[i] === '-t' || args[i] === '--tag') && i + 1 < args.length) {
+        tagName = args[i + 1];
+        i++;
+      } else if (args[i] === '-f' && i + 1 < args.length) {
+        // Dockerfileパスは今回は無視
+        i++;
+      } else if (!args[i].startsWith('-')) {
+        contextPath = args[i];
+      }
+    }
+    
+    // シミュレーション用に新しいイメージを追加
+    const imageName = tagName.includes(':') ? tagName : `${tagName}:latest`;
+    
+    if (!this.state.images.includes(imageName)) {
+      this.state.images.push(imageName);
+    }
+    
+    return {
+      success: true,
+      message: `Successfully built image: ${imageName}\nContext: ${contextPath}`
+    };
+  }
+
+  /**
+   * 'docker network'コマンド処理
+   */
+  private handleDockerNetwork(args: string[]): CommandResult {
+    if (args.length === 0) {
+      return {
+        success: false,
+        message: 'Usage: docker network COMMAND'
+      };
+    }
+
+    const subCommand = args[0];
+    
+    switch (subCommand) {
+      case 'ls':
+      case 'list':
+        return {
+          success: true,
+          message: this.formatNetworkOutput(),
+          data: this.state.networks
+        };
+      
+      case 'create':
+        if (args.length < 2) {
+          return {
+            success: false,
+            message: 'Usage: docker network create [OPTIONS] NETWORK'
+          };
+        }
+        
+        const networkName = args[1];
+        
+        if (this.state.networks.includes(networkName)) {
+          return {
+            success: false,
+            message: `Error: network with name ${networkName} already exists`
+          };
+        }
+        
+        this.state.networks.push(networkName);
+        
+        return {
+          success: true,
+          message: networkName
+        };
+      
+      case 'rm':
+      case 'remove':
+        if (args.length < 2) {
+          return {
+            success: false,
+            message: 'Usage: docker network rm NETWORK [NETWORK...]'
+          };
+        }
+        
+        const networkToRemove = args[1];
+        
+        if (!this.state.networks.includes(networkToRemove)) {
+          return {
+            success: false,
+            message: `Error: No such network: ${networkToRemove}`
+          };
+        }
+        
+        // このネットワークを使用しているコンテナをチェック
+        const usedByContainers = this.state.containers.filter(container => container.networks.includes(networkToRemove));
+        if (usedByContainers.length > 0) {
+          return {
+            success: false,
+            message: `Error: network ${networkToRemove} is in use by containers: ${usedByContainers.map(c => c.id.substring(0, 12)).join(', ')}`
+          };
+        }
+        
+        // 'bridge', 'host', 'none'は削除できない
+        if (['bridge', 'host', 'none'].includes(networkToRemove)) {
+          return {
+            success: false,
+            message: `Error: cannot remove built-in network: ${networkToRemove}`
+          };
+        }
+        
+        const networkIndex = this.state.networks.indexOf(networkToRemove);
+        this.state.networks.splice(networkIndex, 1);
+        
+        return {
+          success: true,
+          message: networkToRemove
+        };
+      
+      default:
+        return {
+          success: false,
+          message: `Error: unknown network command: ${subCommand}`
+        };
+    }
+  }
+
+  /**
+   * 'docker volume'コマンド処理
+   */
+  private handleDockerVolume(args: string[]): CommandResult {
+    if (args.length === 0) {
+      return {
+        success: false,
+        message: 'Usage: docker volume COMMAND'
+      };
+    }
+
+    const subCommand = args[0];
+    
+    switch (subCommand) {
+      case 'ls':
+      case 'list':
+        return {
+          success: true,
+          message: this.formatVolumeOutput(),
+          data: this.state.volumes
+        };
+      
+      case 'create':
+        if (args.length < 2) {
+          return {
+            success: false,
+            message: 'Usage: docker volume create [OPTIONS] [VOLUME]'
+          };
+        }
+        
+        const volumeName = args[1];
+        
+        if (this.state.volumes.includes(volumeName)) {
+          return {
+            success: false,
+            message: `Error: volume with name ${volumeName} already exists`
+          };
+        }
+        
+        this.state.volumes.push(volumeName);
+        
+        return {
+          success: true,
+          message: volumeName
+        };
+      
+      case 'rm':
+      case 'remove':
+        if (args.length < 2) {
+          return {
+            success: false,
+            message: 'Usage: docker volume rm VOLUME [VOLUME...]'
+          };
+        }
+        
+        const volumeToRemove = args[1];
+        
+        if (!this.state.volumes.includes(volumeToRemove)) {
+          return {
+            success: false,
+            message: `Error: No such volume: ${volumeToRemove}`
+          };
+        }
+        
+        // このボリュームを使用しているコンテナをチェック
+        const usedByContainers = this.state.containers.filter(
+          container => container.volumes.some(v => v.host === volumeToRemove || v.container === volumeToRemove)
+        );
+        
+        if (usedByContainers.length > 0) {
+          return {
+            success: false,
+            message: `Error: volume ${volumeToRemove} is in use by containers: ${usedByContainers.map(c => c.id.substring(0, 12)).join(', ')}`
+          };
+        }
+        
+        const volumeIndex = this.state.volumes.indexOf(volumeToRemove);
+        this.state.volumes.splice(volumeIndex, 1);
+        
+        return {
+          success: true,
+          message: volumeToRemove
+        };
+      
+      default:
+        return {
+          success: false,
+          message: `Error: unknown volume command: ${subCommand}`
+        };
+    }
+  }
+
+  /**
+   * 'docker logs'コマンド処理
+   */
+  private handleDockerLogs(args: string[]): CommandResult {
+    if (args.length === 0) {
+      return {
+        success: false,
+        message: 'Usage: docker logs [OPTIONS] CONTAINER'
+      };
+    }
+
+    // 最後の引数をコンテナIDと見なす
+    const containerId = args[args.length - 1];
+    
+    // コンテナが存在するか確認
+    const container = this.state.containers.find(
+      c => c.id === containerId || c.id.startsWith(containerId) || c.name === containerId
+    );
+    
+    if (!container) {
+      return {
+        success: false,
+        message: `Error: No such container: ${containerId}`
+      };
+    }
+    
+    // シミュレーションのため、固定のログメッセージを返す
+    return {
+      success: true,
+      message: `[Container: ${container.name}]\n` +
+               `Starting application...\n` +
+               `Application started successfully.\n` +
+               `Listening on port ${container.ports.map(p => p.container).join(', ') || 'unknown'}\n` +
+               `Ready to accept connections.`
+    };
+  }
+
+  /**
+   * 'docker exec'コマンド処理
+   */
+  private handleDockerExec(args: string[]): CommandResult {
+    if (args.length < 2) {
+      return {
+        success: false,
+        message: 'Usage: docker exec [OPTIONS] CONTAINER COMMAND [ARG...]'
+      };
+    }
+
+    // オプションを除外してコンテナIDとコマンドを取得
+    let containerId = '';
+    let command = '';
+    let interactive = false;
+    
+    for (let i = 0; i < args.length; i++) {
+      if (args[i] === '-i' || args[i] === '--interactive' || args[i] === '-it') {
+        interactive = true;
+      } else if (!containerId) {
+        containerId = args[i];
+      } else {
+        command = args.slice(i).join(' ');
+        break;
+      }
+    }
+    
+    // コンテナが存在するか確認
+    const container = this.state.containers.find(
+      c => c.id === containerId || c.id.startsWith(containerId) || c.name === containerId
+    );
+    
+    if (!container) {
+      return {
+        success: false,
+        message: `Error: No such container: ${containerId}`
+      };
+    }
+    
+    // コンテナが実行中であることを確認
+    if (container.status !== 'running') {
+      return {
+        success: false,
+        message: `Error: Container ${containerId} is not running`
+      };
+    }
+    
+    // シミュレーションのため、コマンドに応じた固定レスポンスを返す
+    if (command.includes('ls')) {
+      return {
+        success: true,
+        message: 'app\nbin\netc\nhome\nlib\nmedia\nopt\nsbin\ntmp\nusr\nvar'
+      };
+    } else if (command.includes('echo')) {
+      const echoText = command.split('echo ')[1]?.replace(/"/g, '') || '';
+      return {
+        success: true,
+        message: echoText
+      };
+    } else if (command.includes('ps')) {
+      return {
+        success: true,
+        message: 'PID   USER     TIME  COMMAND\n    1 root      0:00 /app/entrypoint.sh\n   20 root      0:00 node server.js'
+      };
+    } else {
+      return {
+        success: true,
+        message: `Command executed: ${command}`
+      };
+    }
+  }
+
+  /**
+   * 'docker compose'コマンド処理
+   */
+  private handleDockerCompose(args: string[]): CommandResult {
+    if (args.length === 0) {
+      return {
+        success: false,
+        message: 'Usage: docker compose [OPTIONS] COMMAND'
+      };
+    }
+
+    const subCommand = args[0];
+    
+    switch (subCommand) {
+      case 'up':
+        // 非常に単純化されたdocker-compose up
+        const detached = args.includes('-d') || args.includes('--detach');
+        
+        // シミュレーションのため、デフォルトのサービスを作成
+        const serviceNames = ['app', 'db', 'redis'];
+        
+        // サービスごとにコンテナを作成
+        const newContainers: Container[] = [];
+        
+        serviceNames.forEach(service => {
+          const imageName = `${service}-image:latest`;
+          
+          // イメージが存在しなければ作成
+          if (!this.state.images.includes(imageName)) {
+            this.state.images.push(imageName);
+          }
+          
+          // コンテナID生成
+          const id = `container-${Date.now()}-${Math.floor(Math.random() * 10000)}`;
+          
+          // コンテナ作成
+          const container: Container = {
+            id,
+            name: `studygit-${service}-1`,
+            image: imageName,
+            status: 'running',
+            ports: [],
+            volumes: [],
+            networks: ['studygit_default'],
+            created: new Date().toISOString()
+          };
+          
+          // サービスに応じたポートとボリュームの設定
+          if (service === 'app') {
+            container.ports.push({ host: '3000', container: '3000' });
+            container.volumes.push({ host: './app', container: '/app' });
+          } else if (service === 'db') {
+            container.ports.push({ host: '5432', container: '5432' });
+            container.volumes.push({ host: 'db-data', container: '/var/lib/postgresql/data' });
+          } else if (service === 'redis') {
+            container.ports.push({ host: '6379', container: '6379' });
+          }
+          
+          // コンテナをステートに追加
+          this.state.containers.push(container);
+          newContainers.push(container);
+        });
+        
+        // ネットワークがなければ作成
+        if (!this.state.networks.includes('studygit_default')) {
+          this.state.networks.push('studygit_default');
+        }
+        
+        // ボリュームがなければ作成
+        if (!this.state.volumes.includes('db-data')) {
+          this.state.volumes.push('db-data');
+        }
+        
+        // 応答メッセージの作成
+        const message = detached
+          ? 'Starting containers in detached mode'
+          : `Creating network "studygit_default"\n` +
+            `Creating volume "db-data"\n` +
+            `Creating studygit-db-1     ... done\n` +
+            `Creating studygit-redis-1  ... done\n` +
+            `Creating studygit-app-1    ... done`;
+        
+        return {
+          success: true,
+          message,
+          data: newContainers
+        };
+      
+      case 'down':
+        // シミュレーションのため、単純化したdown処理
+        
+        // docker-composeで作成したコンテナを削除
+        const removedContainers = this.state.containers.filter(
+          container => container.name.startsWith('studygit-')
+        );
+        
+        this.state.containers = this.state.containers.filter(
+          container => !container.name.startsWith('studygit-')
+        );
+        
+        // studygit_defaultネットワークを削除
+        const networkIndex = this.state.networks.indexOf('studygit_default');
+        if (networkIndex !== -1) {
+          this.state.networks.splice(networkIndex, 1);
+        }
+        
+        return {
+          success: true,
+          message: `Stopping containers...\n` +
+                  `Removing containers...\n` +
+                  `Removing network studygit_default\n` +
+                  `Removing volume db-data`,
+          data: removedContainers
+        };
+      
+      default:
+        return {
+          success: false,
+          message: `Error: unknown compose command: ${subCommand}`
+        };
+    }
+  }
+
+  /**
+   * 'docker help'コマンド処理
+   */
+  private handleDockerHelp(): CommandResult {
+    let availableCommands: string[] = [];
+    
+    // 現在のレベルに基づいて利用可能なコマンドのリストを作成
+    if (this.level >= DifficultyLevel.BEGINNER) {
+      availableCommands.push('ps', 'run', 'images', 'stop', 'start', 'help');
+    }
+    
+    if (this.level >= DifficultyLevel.BASIC) {
+      availableCommands.push('pull', 'rm', 'rmi', 'logs');
+    }
+    
+    if (this.level >= DifficultyLevel.INTERMEDIATE) {
+      availableCommands.push('build', 'network', 'volume', 'exec');
+    }
+    
+    if (this.level >= DifficultyLevel.ADVANCED) {
+      availableCommands.push('compose');
+    }
+    
+    const message = `
+Docker コマンドシミュレーション ヘルプ
+現在の難易度レベル: ${this.getLevelName(this.level)}
+
+利用可能なコマンド:
+${availableCommands.map(cmd => `  docker ${cmd}`).join('\n')}
+
+各コマンドの詳細なヘルプは 'docker <コマンド> --help' で確認できます。
+
+レベルアップすると、より高度なコマンドが利用可能になります。
+`;
+    
+    return {
+      success: true,
+      message
+    };
+  }
+
+  /**
+   * 難易度レベルの名前を取得
+   */
+  private getLevelName(level: DifficultyLevel): string {
+    switch (level) {
+      case DifficultyLevel.BEGINNER:
+        return '初心者 (Level 1)';
+      case DifficultyLevel.BASIC:
+        return '基本 (Level 2)';
+      case DifficultyLevel.INTERMEDIATE:
+        return '中級 (Level 3)';
+      case DifficultyLevel.ADVANCED:
+        return '上級 (Level 4)';
+      default:
+        return '不明';
+    }
+  }
+
+  /**
+   * docker ps コマンド出力フォーマット
+   */
+  private formatPsOutput(containers: Container[]): string {
+    if (containers.length === 0) {
+      return 'CONTAINER ID   IMAGE     COMMAND   CREATED   STATUS    PORTS     NAMES';
+    }
+    
+    const header = 'CONTAINER ID   IMAGE             COMMAND      CREATED          STATUS          PORTS                    NAMES';
+    const lines = containers.map(container => {
+      // 作成時間の相対表示
+      const createdTime = this.getRelativeTimeString(new Date(container.created));
+      
+      // ポートマッピングの表示
+      const ports = container.ports.map(p => `${p.host}:${p.container}`).join(', ');
+      
+      // ステータスの表示
+      const status = container.status === 'running' 
+        ? 'Up 2 hours'
+        : container.status === 'exited'
+          ? 'Exited (0)'
+          : container.status;
+      
+      // コマンドの表示（最大20文字）
+      const command = container.command && container.command.length > 20
+        ? container.command.substring(0, 17) + '...'
+        : container.command || '"/bin/sh"';
+      
+      return `${container.id.substring(0, 12)}   ${container.image.padEnd(16)}   "${command}"   ${createdTime.padEnd(15)}   ${status.padEnd(14)}   ${ports.padEnd(23)}   ${container.name}`;
+    });
+    
+    return `${header}\n${lines.join('\n')}`;
+  }
+
+  /**
+   * docker images コマンド出力フォーマット
+   */
+  private formatImagesOutput(): string {
+    if (this.state.images.length === 0) {
+      return 'REPOSITORY   TAG       IMAGE ID       CREATED        SIZE';
+    }
+    
+    const header = 'REPOSITORY       TAG          IMAGE ID       CREATED          SIZE';
+    const lines = this.state.images.map(image => {
+      // イメージ名とタグの分離
+      const [repo, tag] = image.includes(':') ? image.split(':') : [image, 'latest'];
+      
+      // ダミーのイメージID
+      const imageId = `img-${Math.random().toString(36).substring(2, 10)}`;
+      
+      // ダミーのサイズとタイムスタンプ
+      const size = `${Math.floor(Math.random() * 900) + 100}MB`;
+      const created = this.getRelativeTimeString(new Date());
+      
+      return `${repo.padEnd(16)}   ${tag.padEnd(11)}   ${imageId.padEnd(14)}   ${created.padEnd(15)}   ${size}`;
+    });
+    
+    return `${header}\n${lines.join('\n')}`;
+  }
+
+  /**
+   * docker network コマンド出力フォーマット
+   */
+  private formatNetworkOutput(): string {
+    if (this.state.networks.length === 0) {
+      return 'NETWORK ID     NAME      DRIVER    SCOPE';
+    }
+    
+    const header = 'NETWORK ID     NAME           DRIVER    SCOPE';
+    const lines = this.state.networks.map(network => {
+      // ダミーのネットワークID
+      const networkId = `net-${Math.random().toString(36).substring(2, 10)}`;
+      
+      // ドライバとスコープの表示
+      const driver = ['bridge', 'host', 'none'].includes(network) ? network : 'bridge';
+      const scope = 'local';
+      
+      return `${networkId.padEnd(14)}   ${network.padEnd(14)}   ${driver.padEnd(9)}   ${scope}`;
+    });
+    
+    return `${header}\n${lines.join('\n')}`;
+  }
+
+  /**
+   * docker volume コマンド出力フォーマット
+   */
+  private formatVolumeOutput(): string {
+    if (this.state.volumes.length === 0) {
+      return 'DRIVER    VOLUME NAME';
+    }
+    
+    const header = 'DRIVER    VOLUME NAME';
+    const lines = this.state.volumes.map(volume => {
+      return `local     ${volume}`;
+    });
+    
+    return `${header}\n${lines.join('\n')}`;
+  }
+
+  /**
+   * 相対時間の文字列を取得（「2 days ago」などの形式）
+   */
+  private getRelativeTimeString(date: Date): string {
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+    const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+    const diffMinutes = Math.floor(diffMs / (1000 * 60));
+    
+    if (diffDays > 0) {
+      return `${diffDays} days ago`;
+    } else if (diffHours > 0) {
+      return `${diffHours} hours ago`;
+    } else if (diffMinutes > 0) {
+      return `${diffMinutes} minutes ago`;
+    } else {
+      return 'Just now';
+    }
+  }
+}

--- a/container/claudecode/studyGIt/src/components/DockerTerminal.tsx
+++ b/container/claudecode/studyGIt/src/components/DockerTerminal.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import { useState, useEffect } from 'react';
+import styles from './CommandTerminal.module.css'; // 共通のスタイルを使用
+import { DockerState, DifficultyLevel } from './DockerTypes';
+import { DockerCommandInterpreter, DockerCommandEvent, DockerLearningEvent } from './DockerCommandInterpreter';
+
+interface DockerTerminalProps {
+  dockerState: DockerState;
+  onDockerStateChange: (newState: DockerState) => void;
+}
+
+export default function DockerTerminal({ dockerState, onDockerStateChange }: DockerTerminalProps) {
+  const [commandInput, setCommandInput] = useState('');
+  const [commandHistory, setCommandHistory] = useState<string[]>([
+    '$ docker --help',
+    'Docker コマンドシミュレーション ヘルプ',
+    '現在の難易度レベル: 初心者 (Level 1)',
+    '',
+    '利用可能なコマンド:',
+    '  docker ps',
+    '  docker run',
+    '  docker images',
+    '  docker stop',
+    '  docker start',
+    '  docker help',
+    '',
+    '各コマンドの詳細なヘルプは \'docker <コマンド> --help\' で確認できます。',
+    '',
+    'レベルアップすると、より高度なコマンドが利用可能になります。',
+  ]);
+  
+  const [interpreter] = useState(() => new DockerCommandInterpreter(dockerState, DifficultyLevel.BEGINNER));
+  const [difficultyLevel, setDifficultyLevel] = useState<DifficultyLevel>(DifficultyLevel.BEGINNER);
+  const [learningHint, setLearningHint] = useState<string | null>(null);
+
+  // 難易度レベルの変更時に処理
+  useEffect(() => {
+    interpreter.setDifficultyLevel(difficultyLevel);
+  }, [difficultyLevel, interpreter]);
+
+  // Dockerの状態が外部から変更された場合の処理
+  useEffect(() => {
+    interpreter.setState(dockerState);
+  }, [dockerState, interpreter]);
+  
+  // コマンドイベントリスナーの設定
+  useEffect(() => {
+    const commandListener = (event: DockerCommandEvent) => {
+      // コマンド実行結果に学習ヒントがあれば表示
+      if ((event.result as any).learningHint) {
+        setLearningHint((event.result as any).learningHint);
+        // 5秒後に非表示
+        setTimeout(() => setLearningHint(null), 5000);
+      }
+      
+      // 状態変更を親コンポーネントに通知
+      onDockerStateChange(event.currentState);
+    };
+    
+    interpreter.addCommandListener(commandListener);
+    
+    return () => {
+      interpreter.removeCommandListener(commandListener);
+    };
+  }, [interpreter, onDockerStateChange]);
+
+  /**
+   * コマンド実行処理
+   * @param command 実行するコマンド文字列
+   */
+  const handleCommand = (command: string) => {
+    // コマンド履歴に追加
+    setCommandHistory(prev => [...prev, `$ ${command}`]);
+    
+    // コマンドの最初の部分だけを取得
+    const parts = command.split(' ');
+    const mainCommand = parts[0];
+    
+    if (mainCommand === 'docker' || mainCommand === 'docker-compose') {
+      // dockerコマンドの実行
+      const result = interpreter.executeCommand(command);
+      
+      // 結果メッセージを履歴に追加
+      const messageLines = result.message.split('\n');
+      setCommandHistory(prev => [...prev, ...messageLines]);
+      
+      // interpreter経由の状態更新は、コマンドイベントリスナーを通じて処理される
+      // onDockerStateChangeは自動的に呼び出される
+    } else if (command === 'clear') {
+      // クリアコマンド
+      setCommandHistory([]);
+    } else if (command.startsWith('level ')) {
+      // レベル変更コマンド（デバッグ用）
+      const level = parseInt(command.split(' ')[1], 10);
+      if (!isNaN(level) && level >= 1 && level <= 4) {
+        setDifficultyLevel(level as DifficultyLevel);
+        setCommandHistory(prev => [...prev, `難易度レベルを変更しました: ${getLevelName(level as DifficultyLevel)}`]);
+      } else {
+        setCommandHistory(prev => [...prev, 'エラー: 有効なレベルを指定してください（1-4）']);
+      }
+    } else {
+      // サポートされていないコマンド
+      setCommandHistory(prev => [...prev, `エラー: '${mainCommand}' はサポートされていないコマンドです。'docker'で始まるコマンドを使用してください。`]);
+    }
+  };
+
+  /**
+   * 入力フォーム送信時の処理
+   */
+  const handleSubmitCommand = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (commandInput.trim() === '') return;
+    
+    handleCommand(commandInput);
+    setCommandInput('');
+  };
+
+  /**
+   * クイックアクションボタンの処理
+   */
+  const handleQuickAction = (command: string) => {
+    handleCommand(command);
+  };
+
+  /**
+   * 難易度レベル名の取得
+   */
+  const getLevelName = (level: DifficultyLevel): string => {
+    switch (level) {
+      case DifficultyLevel.BEGINNER:
+        return '初心者 (Level 1)';
+      case DifficultyLevel.BASIC:
+        return '基本 (Level 2)';
+      case DifficultyLevel.INTERMEDIATE:
+        return '中級 (Level 3)';
+      case DifficultyLevel.ADVANCED:
+        return '上級 (Level 4)';
+      default:
+        return '不明';
+    }
+  };
+
+  /**
+   * レベルアップボタンの処理
+   */
+  const handleLevelUp = () => {
+    if (difficultyLevel < DifficultyLevel.ADVANCED) {
+      const newLevel = difficultyLevel + 1 as DifficultyLevel;
+      setDifficultyLevel(newLevel);
+      setCommandHistory(prev => [...prev, `難易度レベルがアップしました！: ${getLevelName(newLevel)}`]);
+      setCommandHistory(prev => [...prev, '新しいコマンドが利用可能になりました。「docker help」で確認できます。']);
+    } else {
+      setCommandHistory(prev => [...prev, 'すでに最高レベルです。']);
+    }
+  };
+
+  /**
+   * レベルに応じたクイックアクションボタン表示
+   */
+  const renderQuickActionButtons = () => {
+    // 基本コマンド (Level 1)
+    const basicCommands = [
+      { command: 'docker ps', label: 'docker ps' },
+      { command: 'docker images', label: 'docker images' },
+      { command: 'docker help', label: 'docker help' }
+    ];
+
+    // Level 2 以上で利用可能
+    const level2Commands = difficultyLevel >= DifficultyLevel.BASIC ? [
+      { command: 'docker pull nginx', label: 'docker pull' },
+      { command: 'docker logs', label: 'docker logs' }
+    ] : [];
+
+    // Level 3 以上で利用可能
+    const level3Commands = difficultyLevel >= DifficultyLevel.INTERMEDIATE ? [
+      { command: 'docker network ls', label: 'docker network' },
+      { command: 'docker volume ls', label: 'docker volume' }
+    ] : [];
+
+    // Level 4 で利用可能
+    const level4Commands = difficultyLevel >= DifficultyLevel.ADVANCED ? [
+      { command: 'docker compose', label: 'docker compose' }
+    ] : [];
+
+    const allCommands = [...basicCommands, ...level2Commands, ...level3Commands, ...level4Commands];
+
+    return (
+      <div className={styles.quickActions}>
+        {allCommands.map((cmd, index) => (
+          <button key={index} onClick={() => handleQuickAction(cmd.command)}>
+            {cmd.label}
+          </button>
+        ))}
+        <button className={styles.levelUpButton} onClick={handleLevelUp}>
+          レベルアップ
+        </button>
+      </div>
+    );
+  };
+
+  /**
+   * レベルに応じたヘルプ情報表示
+   */
+  const renderHelpInfo = () => {
+    // レベルに応じて表示するヘルプを変更
+    const helpCommands = [];
+    
+    // Level 1 (BEGINNER)
+    helpCommands.push(
+      { command: 'docker ps', description: 'コンテナ一覧表示' },
+      { command: 'docker run', description: 'コンテナ作成・起動' },
+      { command: 'docker images', description: 'イメージ一覧表示' },
+      { command: 'docker start/stop', description: 'コンテナ起動/停止' }
+    );
+    
+    // Level 2 (BASIC)
+    if (difficultyLevel >= DifficultyLevel.BASIC) {
+      helpCommands.push(
+        { command: 'docker pull', description: 'イメージ取得' },
+        { command: 'docker rm/rmi', description: 'コンテナ/イメージ削除' },
+        { command: 'docker logs', description: 'コンテナログ表示' }
+      );
+    }
+    
+    // Level 3 (INTERMEDIATE)
+    if (difficultyLevel >= DifficultyLevel.INTERMEDIATE) {
+      helpCommands.push(
+        { command: 'docker build', description: 'イメージビルド' },
+        { command: 'docker network', description: 'ネットワーク管理' },
+        { command: 'docker volume', description: 'ボリューム管理' },
+        { command: 'docker exec', description: 'コンテナでコマンド実行' }
+      );
+    }
+    
+    // Level 4 (ADVANCED)
+    if (difficultyLevel >= DifficultyLevel.ADVANCED) {
+      helpCommands.push(
+        { command: 'docker compose', description: '複数コンテナの管理' }
+      );
+    }
+    
+    return (
+      <div className={styles.help}>
+        <h3>使えるコマンド (レベル: {getLevelName(difficultyLevel)})</h3>
+        <ul>
+          {helpCommands.map((cmd, index) => (
+            <li key={index}><code>{cmd.command}</code> - {cmd.description}</li>
+          ))}
+        </ul>
+        {difficultyLevel < DifficultyLevel.ADVANCED && (
+          <div className={styles.levelUpHint}>
+            <p>ヒント: <strong>レベルアップ</strong>ボタンをクリックすると新しいコマンドが解放されます。</p>
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div className={styles.terminal}>
+      <div className={styles.header}>
+        <div className={styles.dots}>
+          <div className={styles.dot} style={{ backgroundColor: '#ff5f56' }}></div>
+          <div className={styles.dot} style={{ backgroundColor: '#ffbd2e' }}></div>
+          <div className={styles.dot} style={{ backgroundColor: '#27c93f' }}></div>
+        </div>
+        <div className={styles.title}>Docker Terminal</div>
+      </div>
+      
+      <div className={styles.terminalBody}>
+        <div className={styles.output}>
+          {commandHistory.map((line, index) => (
+            <div key={index} className={line.startsWith('$') ? styles.command : styles.response}>
+              {line}
+            </div>
+          ))}
+        </div>
+        
+        <form className={styles.inputForm} onSubmit={handleSubmitCommand}>
+          <div className={styles.prompt}>$</div>
+          <input
+            type="text"
+            value={commandInput}
+            onChange={(e) => setCommandInput(e.target.value)}
+            className={styles.input}
+            placeholder="docker コマンドを入力してください..."
+            autoFocus
+          />
+        </form>
+      </div>
+      
+      {learningHint && (
+        <div className={styles.learningHint}>
+          <div className={styles.learningHintHeader}>
+            <span role="img" aria-label="lightbulb">💡</span> Docker学習ポイント
+          </div>
+          <div className={styles.learningHintContent}>
+            {learningHint}
+          </div>
+        </div>
+      )}
+      
+      {renderQuickActionButtons()}
+      {renderHelpInfo()}
+    </div>
+  );
+}

--- a/container/claudecode/studyGIt/src/components/DockerTypes.ts
+++ b/container/claudecode/studyGIt/src/components/DockerTypes.ts
@@ -1,0 +1,122 @@
+/**
+ * DockerTypes.ts
+ * Shared type definitions for Docker-related components
+ */
+
+// コンテナの状態タイプ
+export type ContainerStatus = 'running' | 'exited' | 'created' | 'paused';
+
+// ポートマッピングインターフェース
+export interface PortMapping {
+  host: string;
+  container: string;
+}
+
+// ボリュームマッピングインターフェース
+export interface VolumeMapping {
+  host: string;
+  container: string;
+}
+
+// コンテナインターフェース
+export interface Container {
+  id: string;
+  name: string;
+  image: string;
+  status: ContainerStatus;
+  ports: PortMapping[];
+  volumes: VolumeMapping[];
+  networks: string[];
+  env?: Record<string, string>;
+  command?: string;
+  created: string;
+  // ビジュアライゼーション用拡張プロパティ
+  x?: number;
+  y?: number;
+  highlighted?: boolean;
+}
+
+// イメージインターフェース
+export interface DockerImage {
+  id: string;
+  repository: string;
+  tag: string;
+  size: string;
+  created: string;
+}
+
+// Docker状態インターフェース
+export interface DockerState {
+  containers: Container[];
+  images: string[];
+  volumes: string[];
+  networks: string[];
+}
+
+// Docker状態変更イベント
+export type DockerStateChangeEvent = {
+  type: 'container_created' | 'container_started' | 'container_stopped' | 'container_removed' | 
+        'image_pulled' | 'image_removed' | 
+        'network_created' | 'network_removed' | 
+        'volume_created' | 'volume_removed' |
+        'state_reset';
+  payload: any;
+}
+
+// Docker状態リスナーインターフェース
+export interface DockerStateListener {
+  onDockerStateChange: (state: DockerState, event?: DockerStateChangeEvent) => void;
+}
+
+// コンテナの相互関係
+export interface ContainerRelationship {
+  from: string; // コンテナID または 'host'
+  to: string;   // コンテナID または 'network:network_name' または 'volume:volume_name'
+  type: 'network' | 'volume' | 'depends_on';
+  network?: string; // ネットワーク名（type='network'の場合）
+  volume?: string;  // ボリューム名（type='volume'の場合）
+}
+
+// 教育用ヒントインターフェース
+export interface DockerEducationalTip {
+  id: string;
+  title: string;
+  content: string;
+  elementType: 'container' | 'image' | 'network' | 'volume' | 'port' | 'command';
+  level: 'beginner' | 'intermediate' | 'advanced';
+}
+
+// アニメーションの状態
+export interface AnimationState {
+  isAnimating: boolean;
+  type: string;
+  targetId?: string;
+  progress: number; // 0-100
+  onComplete?: () => void;
+}
+
+// 難易度レベル
+export enum DifficultyLevel {
+  BEGINNER = 1,
+  BASIC = 2,
+  INTERMEDIATE = 3,
+  ADVANCED = 4
+}
+
+// Docker操作イベントオブザーバー
+export interface DockerEventObserver {
+  // イベント通知メソッド
+  notify(event: DockerStateChangeEvent): void;
+}
+
+// Docker操作イベント発行者
+export interface DockerEventEmitter {
+  // オブザーバー登録
+  addObserver(observer: DockerEventObserver): void;
+  
+  // オブザーバー削除
+  removeObserver(observer: DockerEventObserver): void;
+  
+  // イベント発行
+  emitEvent(event: DockerStateChangeEvent): void;
+}

--- a/container/claudecode/studyGIt/src/components/DockerVisualizer.module.css
+++ b/container/claudecode/studyGIt/src/components/DockerVisualizer.module.css
@@ -1,0 +1,889 @@
+.dockerVisualizer {
+  display: flex;
+  flex-direction: column;
+}
+
+.dockerVisualizer h2 {
+  color: var(--primary);
+  margin-bottom: 1rem;
+}
+
+.description {
+  color: #666;
+  margin-bottom: 1.5rem;
+}
+
+.canvas {
+  background-color: #f5f5f5;
+  border-radius: var(--border-radius);
+  padding: 2rem;
+  min-height: 400px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 1.5rem;
+  overflow: auto;
+}
+
+/* 空の状態 */
+.emptyState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  color: #888;
+}
+
+.emptyIcon {
+  font-size: 3rem;
+  margin-bottom: 1rem;
+  animation: float 3s ease-in-out infinite;
+}
+
+@keyframes float {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-15px); }
+}
+
+.emptyState h3 {
+  margin-bottom: 0.5rem;
+}
+
+/* 可視化コンポーネント */
+.visualization {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+/* ホストマシン */
+.hostMachine {
+  width: 90%;
+  border: 2px solid #0078d7;
+  border-radius: 10px;
+  padding: 1.5rem;
+  background-color: #f0f7ff;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.hostHeader {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 1.1rem;
+  color: #0078d7;
+  margin-bottom: 1rem;
+  text-align: center;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid #cce5ff;
+}
+
+.hostIcon {
+  margin-right: 0.5rem;
+  font-size: 1.2rem;
+}
+
+.hostContent {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.sectionTitle {
+  font-weight: 600;
+  color: #333;
+  margin-bottom: 1rem;
+  padding-bottom: 0.3rem;
+  border-bottom: 1px dashed #ccc;
+}
+
+/* ネットワーク */
+.networks {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1.5rem;
+  width: 100%;
+}
+
+.networkDiagram {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  margin-top: 0.5rem;
+}
+
+.network {
+  background-color: #e3f2fd;
+  border: 1px solid #bbdefb;
+  border-radius: 6px;
+  padding: 1rem;
+  flex: 1;
+  min-width: 200px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  position: relative;
+}
+
+.network:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  transform: translateY(-2px);
+}
+
+.networkLabel {
+  font-weight: 500;
+  color: #0277bd;
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.75rem;
+  font-size: 1rem;
+}
+
+.networkIcon {
+  margin-right: 0.5rem;
+}
+
+.networkContainers {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.networkContainerBadge {
+  padding: 0.3rem 0.6rem;
+  border-radius: 30px;
+  font-size: 0.8rem;
+  background-color: #e0e0e0;
+  color: #333;
+}
+
+.networkContainerBadge.running {
+  background-color: rgba(76, 175, 80, 0.2);
+  color: #2e7d32;
+}
+
+.networkContainerBadge.exited {
+  background-color: rgba(244, 67, 54, 0.2);
+  color: #c62828;
+}
+
+.networkContainerBadge.created {
+  background-color: rgba(255, 152, 0, 0.2);
+  color: #ef6c00;
+}
+
+/* コンテナ */
+.containers {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.container {
+  background-color: white;
+  border-radius: 8px;
+  padding: 1rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  width: 280px;
+  transition: all 0.3s ease;
+}
+
+.container:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
+}
+
+/* コンテナステータス */
+.container.running {
+  border-left: 4px solid #4caf50;
+}
+
+.container.exited {
+  border-left: 4px solid #f44336;
+}
+
+.container.created {
+  border-left: 4px solid #ff9800;
+}
+
+.containerHeader {
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.containerStatusIcon {
+  margin-right: 0.5rem;
+}
+
+.containerName {
+  font-weight: 600;
+  color: #333;
+  font-size: 1rem;
+}
+
+.containerDetails {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.containerImage {
+  font-family: monospace;
+  background-color: #f8f9fa;
+  padding: 0.5rem;
+  border-radius: 4px;
+  font-size: 0.85rem;
+}
+
+.containerPorts, .containerVolumes, .containerNetworks {
+  font-size: 0.85rem;
+}
+
+.containerPorts > span, .containerVolumes > span, .containerNetworks > span {
+  color: #666;
+  display: block;
+  margin-bottom: 0.3rem;
+}
+
+.portMapping, .volumeMapping {
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.25rem;
+  background-color: #f8f9fa;
+  border-radius: 4px;
+  padding: 0.3rem 0.5rem;
+}
+
+.hostPort, .hostVolume {
+  color: #0078d7;
+  font-family: monospace;
+}
+
+.containerPort, .containerVolume {
+  color: #4caf50;
+  font-family: monospace;
+}
+
+.mappingArrow {
+  margin: 0 0.5rem;
+  color: #999;
+}
+
+.networkTag {
+  display: inline-block;
+  background-color: #e3f2fd;
+  color: #0277bd;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  margin-right: 0.5rem;
+  margin-bottom: 0.5rem;
+  font-size: 0.8rem;
+}
+
+/* イメージ */
+.images {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1.5rem;
+  width: 100%;
+}
+
+.imagesList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 0.5rem;
+}
+
+.imageItem {
+  background-color: #fafafa;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 0.75rem;
+  display: flex;
+  align-items: center;
+  min-width: 140px;
+  flex: 1;
+  transition: all 0.2s ease;
+  cursor: pointer;
+  position: relative;
+}
+
+.imageItem:hover {
+  background-color: #f5f5f5;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.imageIcon {
+  margin-right: 0.75rem;
+  font-size: 1.2rem;
+}
+
+.imageDetails {
+  display: flex;
+  flex-direction: column;
+}
+
+.imageName {
+  font-weight: 500;
+  color: #333;
+}
+
+.imageTag {
+  font-size: 0.8rem;
+  color: #666;
+  background-color: #eee;
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  display: inline-block;
+  margin-top: 0.3rem;
+}
+
+/* ボリューム */
+.volumes {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.volumesList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 0.5rem;
+}
+
+.volume {
+  background-color: #fff3e0;
+  border: 1px solid #ffe0b2;
+  border-radius: 6px;
+  padding: 0.75rem;
+  flex: 1;
+  min-width: 200px;
+  display: flex;
+  align-items: center;
+  transition: all 0.2s ease;
+  cursor: pointer;
+  position: relative;
+}
+
+.volume:hover {
+  background-color: #ffecb3;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.volumeIcon {
+  margin-right: 0.75rem;
+  font-size: 1.2rem;
+}
+
+.volumeLabel {
+  font-weight: 500;
+  color: #e65100;
+}
+
+/* 凡例 */
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  padding: 1rem;
+  background-color: #f9f9f9;
+  border-radius: var(--border-radius);
+  margin-bottom: 1.5rem;
+  justify-content: center;
+}
+
+.legendItem {
+  display: flex;
+  align-items: center;
+  font-size: 0.9rem;
+}
+
+.legendSymbol {
+  width: 15px;
+  height: 15px;
+  margin-right: 0.5rem;
+}
+
+.runningLegend {
+  background-color: #4caf50;
+  border-radius: 2px;
+}
+
+.exitedLegend {
+  background-color: #f44336;
+  border-radius: 2px;
+}
+
+.createdLegend {
+  background-color: #ff9800;
+  border-radius: 2px;
+}
+
+.volumeLegend {
+  background-color: #e65100;
+  border-radius: 2px;
+}
+
+.networkLegend {
+  background-color: #0277bd;
+  border-radius: 2px;
+}
+
+/* アニメーション用スタイル */
+.canvasWrapper {
+  position: relative;
+  width: 100%;
+}
+
+/* 関係線と可視化関連のスタイル */
+.relationshipLines {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 10;
+}
+
+.relationshipPath {
+  stroke: #aaa;
+  stroke-width: 1.5px;
+  stroke-dasharray: 5,5;
+  fill: none;
+  pointer-events: none;
+}
+
+.relationshipPath.network {
+  stroke: #0277bd;
+  stroke-width: 2px;
+}
+
+.relationshipPath.volume {
+  stroke: #e65100;
+  stroke-width: 2px;
+}
+
+.relationshipMarker {
+  fill: #aaa;
+}
+
+.relationshipMarker.network {
+  fill: #0277bd;
+}
+
+.relationshipMarker.volume {
+  fill: #e65100;
+}
+
+.animationOverlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.15);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  z-index: 50;
+  border-radius: var(--border-radius);
+}
+
+.animationStatus {
+  background-color: white;
+  padding: 0.75rem 1.5rem;
+  border-radius: 30px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  font-weight: 500;
+  margin-bottom: 1rem;
+  color: var(--primary);
+  animation: pulse 1.5s infinite;
+}
+
+@keyframes pulse {
+  0% { box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15); transform: scale(1); }
+  50% { box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2); transform: scale(1.03); }
+  100% { box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15); transform: scale(1); }
+}
+
+.progressBar {
+  height: 4px;
+  background-color: var(--primary);
+  background: linear-gradient(90deg, var(--primary), #8c9eff);
+  border-radius: 2px;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  box-shadow: 0 0 8px rgba(99, 102, 241, 0.6);
+  animation: progressGlow 1.5s infinite alternate;
+}
+
+@keyframes progressGlow {
+  from { box-shadow: 0 0 5px rgba(99, 102, 241, 0.5); }
+  to { box-shadow: 0 0 12px rgba(99, 102, 241, 0.8); }
+}
+
+/* アニメーションクラス */
+.animateCreate {
+  animation: createAnimation 0.6s ease-out;
+}
+
+.animateStart {
+  animation: startAnimation 0.4s ease-out;
+}
+
+.animateStop {
+  animation: stopAnimation 0.4s ease-out;
+}
+
+.animateRemove {
+  animation: removeAnimation 0.5s ease-out;
+}
+
+@keyframes createAnimation {
+  from { opacity: 0; transform: scale(0.7); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+@keyframes startAnimation {
+  0% { box-shadow: 0 0 0 0 rgba(76, 175, 80, 0.7); transform: scale(1); }
+  50% { box-shadow: 0 0 0 15px rgba(76, 175, 80, 0.3); transform: scale(1.05); }
+  100% { box-shadow: 0 0 0 0 rgba(76, 175, 80, 0); transform: scale(1); }
+}
+
+@keyframes stopAnimation {
+  0% { box-shadow: 0 0 0 0 rgba(244, 67, 54, 0.7); transform: scale(1); }
+  50% { box-shadow: 0 0 0 15px rgba(244, 67, 54, 0.3); transform: scale(0.95); }
+  100% { box-shadow: 0 0 0 0 rgba(244, 67, 54, 0); transform: scale(1); }
+}
+
+@keyframes removeAnimation {
+  0% { opacity: 1; transform: scale(1) rotate(0deg); }
+  30% { opacity: 0.8; transform: scale(0.9) rotate(-2deg); }
+  100% { opacity: 0; transform: scale(0.7) rotate(5deg); }
+}
+
+/* 教育用ヒントパネル */
+.activeTips {
+  background-color: white;
+  border-radius: var(--border-radius);
+  padding: 1.25rem;
+  margin: 1.5rem 0;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  border-left: 4px solid var(--primary);
+  position: relative;
+  overflow: hidden;
+}
+
+.activeTips::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 100px;
+  height: 100px;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.1), transparent 50%);
+  border-radius: 0 0 0 100%;
+}
+
+.tipsHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid #eee;
+}
+
+.tipsHeader h3 {
+  margin: 0;
+  color: var(--primary);
+}
+
+.closeTips {
+  background-color: transparent;
+  border: none;
+  color: #666;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  transition: all 0.2s;
+}
+
+.closeTips:hover {
+  background-color: #f0f0f0;
+  color: #333;
+}
+
+.tipsList {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.tipItem {
+  padding: 0.75rem;
+  background-color: #f9f9f9;
+  border-radius: 6px;
+  border-left: 3px solid var(--primary);
+  transition: all 0.3s ease;
+}
+
+.tipItem:hover {
+  background-color: #f0f0f7;
+  transform: translateX(2px);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+}
+
+.tipItem h4 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  color: #333;
+  font-size: 0.95rem;
+}
+
+.tipItem p {
+  margin: 0;
+  color: #555;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+/* ツールチップと詳細パネル */
+.tooltip {
+  position: absolute;
+  top: calc(100% + 10px);
+  left: 0;
+  background-color: white;
+  border-radius: 8px;
+  padding: 1rem;
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.2);
+  z-index: 100;
+  width: 300px;
+  animation: fadeIn 0.3s ease;
+  cursor: default;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(-10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.tooltipHeader {
+  font-weight: 600;
+  color: var(--primary);
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid #eee;
+}
+
+.tooltipBody {
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.tooltipBody p {
+  margin-bottom: 0.5rem;
+}
+
+.tooltipBody ul {
+  padding-left: 1.2rem;
+  margin: 0.5rem 0;
+}
+
+.tooltipBody li {
+  margin-bottom: 0.3rem;
+}
+
+.highlight {
+  font-weight: 600;
+  background-color: #fffde7;
+  padding: 0 3px;
+  border-radius: 3px;
+}
+
+.containerDetailPanel {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: white;
+  border-radius: 10px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+  width: 500px;
+  max-width: 90%;
+  max-height: 90vh;
+  overflow-y: auto;
+  z-index: 200;
+  animation: zoomIn 0.3s ease;
+}
+
+@keyframes zoomIn {
+  from { opacity: 0; transform: translate(-50%, -50%) scale(0.9); }
+  to { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+}
+
+.runningDetail {
+  border-top: 5px solid var(--success);
+}
+
+.exitedDetail {
+  border-top: 5px solid var(--danger);
+}
+
+.createdDetail {
+  border-top: 5px solid var(--warning, #ff9800);
+}
+
+.detailHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  border-bottom: 1px solid #eee;
+}
+
+.detailTitle {
+  font-weight: 600;
+  font-size: 1.1rem;
+  display: flex;
+  align-items: center;
+}
+
+.detailClose {
+  cursor: pointer;
+  padding: 0.3rem 0.6rem;
+  border-radius: 50%;
+  transition: all 0.2s;
+}
+
+.detailClose:hover {
+  background-color: #f0f0f0;
+}
+
+.detailContent {
+  padding: 1rem;
+}
+
+.detailSection {
+  margin-bottom: 1.5rem;
+}
+
+.detailSection h4 {
+  color: #333;
+  margin-bottom: 0.75rem;
+  font-size: 1rem;
+}
+
+.detailRow {
+  display: flex;
+  margin-bottom: 0.5rem;
+  align-items: center;
+}
+
+.detailLabel {
+  width: 100px;
+  color: #666;
+  font-size: 0.9rem;
+}
+
+.detailValue {
+  font-family: monospace;
+  color: #333;
+  font-size: 0.9rem;
+}
+
+.noDetail {
+  color: #999;
+  font-style: italic;
+  font-size: 0.9rem;
+}
+
+.detailHelp {
+  background-color: #f9f9f9;
+  border-radius: 6px;
+  padding: 1rem;
+  margin-top: 1rem;
+}
+
+.detailHelp h4 {
+  color: var(--primary);
+  margin-bottom: 0.5rem;
+  font-size: 0.95rem;
+}
+
+.detailHelp p {
+  color: #333;
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.noMapping {
+  color: #999;
+  font-style: italic;
+  font-size: 0.85rem;
+  padding: 0.3rem 0;
+}
+
+.containerStatusText {
+  margin-left: auto;
+  font-size: 0.8rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+}
+
+.running .containerStatusText {
+  background-color: rgba(76, 175, 80, 0.1);
+  color: #2e7d32;
+}
+
+.exited .containerStatusText {
+  background-color: rgba(244, 67, 54, 0.1);
+  color: #c62828;
+}
+
+.created .containerStatusText {
+  background-color: rgba(255, 152, 0, 0.1);
+  color: #ef6c00;
+}
+
+/* 教育用ヒント */
+.educationTips {
+  background-color: #f5f5f5;
+  background: linear-gradient(to bottom right, #f5f5f5, #f0f0f7);
+  border: 1px solid #e0e0e0;
+  border-radius: var(--border-radius);
+  padding: 1.5rem;
+}
+
+.educationTips h3 {
+  color: var(--primary);
+  margin-bottom: 1rem;
+  font-size: 1.1rem;
+}
+
+.educationTips ul {
+  padding-left: 1.5rem;
+}
+
+.educationTips li {
+  margin-bottom: 0.5rem;
+  line-height: 1.5;
+}
+
+.educationTips strong {
+  color: var(--primary);
+}

--- a/container/claudecode/studyGIt/src/components/DockerVisualizer.tsx
+++ b/container/claudecode/studyGIt/src/components/DockerVisualizer.tsx
@@ -1,0 +1,1122 @@
+"use client";
+
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import styles from './DockerVisualizer.module.css';
+import { 
+  DockerState, Container, PortMapping, VolumeMapping, 
+  DockerStateChangeEvent, DockerEventObserver, ContainerRelationship,
+  DockerEducationalTip, AnimationState
+} from './DockerTypes';
+
+interface DockerVisualizerProps {
+  dockerState: DockerState;
+  onDockerStateChange?: (newState: DockerState, event?: DockerStateChangeEvent) => void;
+  showAnimations?: boolean;
+  educationalMode?: boolean;
+  difficultyLevel?: number;
+}
+
+export default function DockerVisualizer({ 
+  dockerState, 
+  onDockerStateChange,
+  showAnimations = true,
+  educationalMode = true,
+  difficultyLevel = 1
+}: DockerVisualizerProps) {
+  const canvasRef = useRef<HTMLDivElement>(null);
+  const [previousState, setPreviousState] = useState<DockerState | null>(null);
+  const [animationState, setAnimationState] = useState<AnimationState>({
+    isAnimating: false,
+    type: 'none',
+    progress: 0
+  });
+  const [selectedElement, setSelectedElement] = useState<{
+    type: 'container' | 'image' | 'network' | 'volume' | null,
+    id: string | null
+  }>({
+    type: null,
+    id: null
+  });
+  
+  // コンテナ間の関係を計算
+  const [relationships, setRelationships] = useState<ContainerRelationship[]>([]);
+  
+  // 教育用ヒント
+  const [visibleTips, setVisibleTips] = useState<DockerEducationalTip[]>([]);
+  
+  // アニメーション効果用のタイマー参照
+  const animationTimerRef = useRef<NodeJS.Timeout | null>(null);
+  
+  // アニメーション完了時の処理
+  const handleAnimationComplete = useCallback(() => {
+    if (animationState.onComplete) {
+      animationState.onComplete();
+    }
+    setAnimationState(prev => ({ ...prev, isAnimating: false, progress: 100 }));
+    
+    // ステータス変更に応じた教育用ヒントを表示（自動）
+    if (educationalMode && animationState.type && animationState.targetId) {
+      const eventType = animationState.type.split('_')[0] as 'container' | 'network' | 'volume' | 'image';
+      setTimeout(() => {
+        const tips = getEducationalTipsForEvent(eventType, animationState.type);
+        if (tips.length > 0) {
+          setVisibleTips(tips);
+          // 10秒後に自動で閉じる
+          if (animationTimerRef.current) {
+            clearTimeout(animationTimerRef.current);
+          }
+          animationTimerRef.current = setTimeout(() => setVisibleTips([]), 10000);
+        }
+      }, 500);
+    }
+  }, [animationState, educationalMode]);
+  
+  // Docker状態の変更を検出して処理
+  useEffect(() => {
+    if (!previousState) {
+      // 初回レンダリング時は前回の状態を設定するだけ
+      setPreviousState(dockerState);
+      return;
+    }
+
+    // 状態の変化を検出
+    const detectStateChanges = () => {
+      // 新しいコンテナの検出
+      const newContainers = dockerState.containers.filter(
+        container => !previousState.containers.some(c => c.id === container.id)
+      );
+      
+      if (newContainers.length > 0) {
+        setAnimationState({
+          isAnimating: true,
+          type: 'container_created',
+          targetId: newContainers[0].id,
+          progress: 0
+        });
+        
+        // アニメーション完了後に実行するコールバック
+        setTimeout(() => {
+          handleAnimationComplete();
+        }, showAnimations ? 600 : 0);
+      }
+      
+      // ステータスが変更されたコンテナの検出
+      const statusChangedContainers = dockerState.containers.filter(container => {
+        const previousContainer = previousState.containers.find(c => c.id === container.id);
+        return previousContainer && previousContainer.status !== container.status;
+      });
+      
+      if (statusChangedContainers.length > 0) {
+        const changedContainer = statusChangedContainers[0];
+        const eventType = changedContainer.status === 'running' 
+          ? 'container_started' 
+          : 'container_stopped';
+          
+        setAnimationState({
+          isAnimating: true,
+          type: eventType,
+          targetId: changedContainer.id,
+          progress: 0
+        });
+        
+        setTimeout(() => {
+          handleAnimationComplete();
+        }, showAnimations ? 400 : 0);
+      }
+      
+      // 削除されたコンテナの検出
+      const removedContainers = previousState.containers.filter(
+        container => !dockerState.containers.some(c => c.id === container.id)
+      );
+      
+      if (removedContainers.length > 0) {
+        setAnimationState({
+          isAnimating: true,
+          type: 'container_removed',
+          targetId: removedContainers[0].id,
+          progress: 0
+        });
+        
+        setTimeout(() => {
+          handleAnimationComplete();
+        }, showAnimations ? 500 : 0);
+      }
+      
+      // ネットワークの変更検出
+      if (previousState.networks.length !== dockerState.networks.length) {
+        const eventType = previousState.networks.length < dockerState.networks.length
+          ? 'network_created'
+          : 'network_removed';
+          
+        setAnimationState({
+          isAnimating: true,
+          type: eventType,
+          progress: 0
+        });
+        
+        setTimeout(() => {
+          handleAnimationComplete();
+        }, showAnimations ? 300 : 0);
+      }
+      
+      // ボリュームの変更検出
+      if (previousState.volumes.length !== dockerState.volumes.length) {
+        const eventType = previousState.volumes.length < dockerState.volumes.length
+          ? 'volume_created'
+          : 'volume_removed';
+          
+        setAnimationState({
+          isAnimating: true,
+          type: eventType,
+          progress: 0
+        });
+        
+        setTimeout(() => {
+          handleAnimationComplete();
+        }, showAnimations ? 300 : 0);
+      }
+    };
+    
+    // 前回の状態と現在の状態が異なる場合に変更を検出
+    if (JSON.stringify(previousState) !== JSON.stringify(dockerState)) {
+      detectStateChanges();
+      // 新しい状態を保存
+      setPreviousState(dockerState);
+    }
+  }, [dockerState, previousState, showAnimations, handleAnimationComplete]);
+  
+  // コンテナ間の関係を計算
+  useEffect(() => {
+    const newRelationships: ContainerRelationship[] = [];
+    
+    // コンテナとネットワークの関係
+    dockerState.containers.forEach(container => {
+      container.networks.forEach(network => {
+        newRelationships.push({
+          from: container.id,
+          to: `network:${network}`,
+          type: 'network',
+          network
+        });
+      });
+      
+      // コンテナとボリュームの関係
+      container.volumes.forEach(volume => {
+        newRelationships.push({
+          from: container.id,
+          to: `volume:${volume.host}`,
+          type: 'volume',
+          volume: volume.host
+        });
+      });
+    });
+    
+    setRelationships(newRelationships);
+  }, [dockerState]);
+  
+  // レンダリング用のメイン関数
+  useEffect(() => {
+    if (!canvasRef.current) return;
+    
+    // 既存の要素をクリア
+    while (canvasRef.current.firstChild) {
+      canvasRef.current.removeChild(canvasRef.current.firstChild);
+    }
+    
+    // アニメーション状態をリセット（新たにレンダリングする場合）
+    if (animationState.isAnimating && animationState.progress >= 100) {
+      setAnimationState({
+        isAnimating: false,
+        type: 'none',
+        progress: 0
+      });
+    }
+    
+    // コンテナがない場合は初期メッセージを表示
+    if (dockerState.containers.length === 0) {
+      const emptyMsg = document.createElement('div');
+      emptyMsg.className = styles.emptyState;
+      emptyMsg.innerHTML = `
+        <div class="${styles.emptyIcon}">🐳</div>
+        <h3>まだコンテナはありません</h3>
+        <p>コンテナを作成すると、ここに可視化されます。</p>
+      `;
+      canvasRef.current.appendChild(emptyMsg);
+      return;
+    }
+    
+    // Docker可視化のためのエレメントを構築
+    const visualization = document.createElement('div');
+    visualization.className = styles.visualization;
+    
+    // ホストマシン要素
+    const hostMachine = document.createElement('div');
+    hostMachine.className = styles.hostMachine;
+    hostMachine.innerHTML = `
+      <div class="${styles.hostHeader}">
+        <span class="${styles.hostIcon}">💻</span>
+        ホストマシン
+      </div>
+      <div class="${styles.hostContent}"></div>
+    `;
+    
+    // イメージセクション
+    const images = document.createElement('div');
+    images.className = styles.images;
+    images.innerHTML = `<div class="${styles.sectionTitle}">Dockerイメージ</div>`;
+    
+    const imagesList = document.createElement('div');
+    imagesList.className = styles.imagesList;
+    
+    dockerState.images.forEach(image => {
+      const imageEl = document.createElement('div');
+      imageEl.className = styles.imageItem;
+      
+      // イメージ名とタグの分離
+      const [imageName, imageTag] = image.split(':');
+      
+      imageEl.innerHTML = `
+        <div class="${styles.imageIcon}">📦</div>
+        <div class="${styles.imageDetails}">
+          <div class="${styles.imageName}">${imageName}</div>
+          <div class="${styles.imageTag}">${imageTag || 'latest'}</div>
+        </div>
+      `;
+      imagesList.appendChild(imageEl);
+      
+      // インタラクティブなツールチップ
+      imageEl.addEventListener('click', () => {
+        const tooltip = document.createElement('div');
+        tooltip.className = styles.tooltip;
+        tooltip.innerHTML = `
+          <div class="${styles.tooltipHeader}">Dockerイメージとは</div>
+          <div class="${styles.tooltipBody}">
+            <p>Dockerイメージはアプリケーションと実行環境を含むスナップショットです。</p>
+            <p>イメージは<span class="${styles.highlight}">読み取り専用</span>で、コンテナ起動の元になります。</p>
+            <p><strong>名前:タグ</strong>形式で識別され、タグがない場合は<strong>latest</strong>とみなされます。</p>
+          </div>
+        `;
+        
+        // 既存のツールチップを削除
+        const existingTooltips = canvasRef.current?.querySelectorAll(`.${styles.tooltip}`);
+        existingTooltips?.forEach(tip => tip.remove());
+        
+        // 新しいツールチップを追加
+        imageEl.appendChild(tooltip);
+        
+        // クリックでツールチップを閉じる
+        tooltip.addEventListener('click', (e) => {
+          e.stopPropagation();
+          tooltip.remove();
+        });
+      });
+    });
+    
+    images.appendChild(imagesList);
+    
+    // ネットワークセクション
+    const networks = document.createElement('div');
+    networks.className = styles.networks;
+    networks.innerHTML = `<div class="${styles.sectionTitle}">ネットワーク</div>`;
+    
+    const networkDiagram = document.createElement('div');
+    networkDiagram.className = styles.networkDiagram;
+    
+    dockerState.networks.forEach(network => {
+      const networkEl = document.createElement('div');
+      networkEl.className = styles.network;
+      networkEl.innerHTML = `
+        <div class="${styles.networkLabel}">
+          <span class="${styles.networkIcon}">🔄</span>
+          ${network}
+        </div>
+        <div class="${styles.networkContainers}">
+          ${dockerState.containers
+            .filter(container => container.networks.includes(network))
+            .map(container => {
+              let statusClass = '';
+              if (container.status === 'running') statusClass = styles.running;
+              else if (container.status === 'exited') statusClass = styles.exited;
+              else if (container.status === 'created') statusClass = styles.created;
+              
+              return `
+                <div class="${styles.networkContainerBadge} ${statusClass}">
+                  ${container.name}
+                </div>
+              `;
+            }).join('')}
+        </div>
+      `;
+      networkDiagram.appendChild(networkEl);
+      
+      // インタラクティブ要素の追加
+      networkEl.addEventListener('click', () => {
+        const tooltip = document.createElement('div');
+        tooltip.className = styles.tooltip;
+        tooltip.innerHTML = `
+          <div class="${styles.tooltipHeader}">Dockerネットワークとは</div>
+          <div class="${styles.tooltipBody}">
+            <p>Dockerネットワークはコンテナ間の通信を可能にする仮想ネットワークです。</p>
+            <p>同じネットワーク上のコンテナは<span class="${styles.highlight}">コンテナ名</span>でお互いに通信できます。</p>
+            <p><strong>ブリッジネットワーク</strong>：デフォルトのネットワークタイプ</p>
+            <p><strong>ホストネットワーク</strong>：ホストのネットワークを直接使用</p>
+          </div>
+        `;
+        
+        // 既存のツールチップを削除
+        const existingTooltips = canvasRef.current?.querySelectorAll(`.${styles.tooltip}`);
+        existingTooltips?.forEach(tip => tip.remove());
+        
+        // 新しいツールチップを追加
+        networkEl.appendChild(tooltip);
+        
+        // クリックでツールチップを閉じる
+        tooltip.addEventListener('click', (e) => {
+          e.stopPropagation();
+          tooltip.remove();
+        });
+      });
+    });
+    
+    networks.appendChild(networkDiagram);
+    
+    // コンテナセクション
+    const containers = document.createElement('div');
+    containers.className = styles.containers;
+    containers.innerHTML = `<div class="${styles.sectionTitle}">コンテナ</div>`;
+    
+    dockerState.containers.forEach(container => {
+      const containerEl = document.createElement('div');
+      containerEl.className = `${styles.container} ${styles[container.status]}`;
+      
+      // ステータスに応じたアイコンを表示
+      let statusIcon = '⚪️';
+      let statusText = 'Unknown';
+      if (container.status === 'running') {
+        statusIcon = '🟢';
+        statusText = '実行中';
+      } else if (container.status === 'exited') {
+        statusIcon = '🔴';
+        statusText = '停止';
+      } else if (container.status === 'created') {
+        statusIcon = '🟡';
+        statusText = '作成済み';
+      }
+      
+      containerEl.innerHTML = `
+        <div class="${styles.containerHeader}">
+          <span class="${styles.containerStatusIcon}">${statusIcon}</span>
+          <span class="${styles.containerName}">${container.name}</span>
+          <span class="${styles.containerStatusText}">${statusText}</span>
+        </div>
+        <div class="${styles.containerDetails}">
+          <div class="${styles.containerImage}">イメージ: ${container.image}</div>
+          <div class="${styles.containerPorts}">
+            <span>ポート:</span>
+            ${container.ports.length === 0 ? 
+              '<div class="' + styles.noMapping + '">なし</div>' :
+              container.ports.map(port => 
+                `<div class="${styles.portMapping}">
+                  <span class="${styles.hostPort}">${port.host}</span>
+                  <span class="${styles.mappingArrow}">→</span>
+                  <span class="${styles.containerPort}">${port.container}</span>
+                </div>`
+              ).join('')
+            }
+          </div>
+          <div class="${styles.containerVolumes}">
+            <span>ボリューム:</span>
+            ${container.volumes.length === 0 ? 
+              '<div class="' + styles.noMapping + '">なし</div>' :
+              container.volumes.map(volume => 
+                `<div class="${styles.volumeMapping}">
+                  <span class="${styles.hostVolume}">${volume.host}</span>
+                  <span class="${styles.mappingArrow}">→</span>
+                  <span class="${styles.containerVolume}">${volume.container}</span>
+                </div>`
+              ).join('')
+            }
+          </div>
+          <div class="${styles.containerNetworks}">
+            <span>ネットワーク:</span>
+            ${container.networks.map(network => 
+              `<div class="${styles.networkTag}">${network}</div>`
+            ).join('')}
+          </div>
+        </div>
+      `;
+      
+      containers.appendChild(containerEl);
+      
+      // インタラクティブ要素の追加
+      containerEl.addEventListener('click', () => {
+        // コンテナ詳細パネルを表示する機能
+        const detailPanel = document.createElement('div');
+        detailPanel.className = styles.containerDetailPanel;
+        
+        // ステータスに応じた背景色のクラスを適用
+        detailPanel.classList.add(styles[`${container.status}Detail`]);
+        
+        detailPanel.innerHTML = `
+          <div class="${styles.detailHeader}">
+            <div class="${styles.detailTitle}">
+              <span class="${styles.containerStatusIcon}">${statusIcon}</span>
+              ${container.name}
+            </div>
+            <div class="${styles.detailClose}">✕</div>
+          </div>
+          <div class="${styles.detailContent}">
+            <div class="${styles.detailSection}">
+              <h4>コンテナ情報</h4>
+              <div class="${styles.detailRow}">
+                <span class="${styles.detailLabel}">ID:</span>
+                <span class="${styles.detailValue}">${container.id}</span>
+              </div>
+              <div class="${styles.detailRow}">
+                <span class="${styles.detailLabel}">ステータス:</span>
+                <span class="${styles.detailValue}">${statusText}</span>
+              </div>
+              <div class="${styles.detailRow}">
+                <span class="${styles.detailLabel}">イメージ:</span>
+                <span class="${styles.detailValue}">${container.image}</span>
+              </div>
+            </div>
+            
+            <div class="${styles.detailSection}">
+              <h4>ポートマッピング</h4>
+              ${container.ports.length === 0 ? 
+                '<div class="' + styles.noDetail + '">ポートマッピングはありません</div>' :
+                container.ports.map(port => 
+                  `<div class="${styles.detailRow}">
+                    <span class="${styles.detailLabel}">ホスト:コンテナ</span>
+                    <span class="${styles.detailValue}">${port.host}:${port.container}</span>
+                  </div>`
+                ).join('')
+              }
+            </div>
+            
+            <div class="${styles.detailSection}">
+              <h4>ボリューム</h4>
+              ${container.volumes.length === 0 ? 
+                '<div class="' + styles.noDetail + '">ボリュームはありません</div>' :
+                container.volumes.map(volume => 
+                  `<div class="${styles.detailRow}">
+                    <span class="${styles.detailLabel}">ホスト:</span>
+                    <span class="${styles.detailValue}">${volume.host}</span>
+                  </div>
+                  <div class="${styles.detailRow}">
+                    <span class="${styles.detailLabel}">コンテナ:</span>
+                    <span class="${styles.detailValue}">${volume.container}</span>
+                  </div>`
+                ).join('')
+              }
+            </div>
+            
+            <div class="${styles.detailSection}">
+              <h4>ネットワーク</h4>
+              ${container.networks.map(network => 
+                `<div class="${styles.detailRow}">
+                  <span class="${styles.detailValue}">${network}</span>
+                </div>`
+              ).join('')}
+            </div>
+            
+            <div class="${styles.detailHelp}">
+              <h4>Dockerコンテナとは</h4>
+              <p>
+                Dockerコンテナはイメージのインスタンスで、独立した実行環境を提供します。
+                ポートマッピングでホストとコンテナ間の通信を可能にし、ボリュームでデータを永続化します。
+              </p>
+            </div>
+          </div>
+        `;
+        
+        // 既存の詳細パネルを削除
+        const existingPanels = canvasRef.current?.querySelectorAll(`.${styles.containerDetailPanel}`);
+        existingPanels?.forEach(panel => panel.remove());
+        
+        // 詳細パネルの閉じるボタンの機能を追加
+        detailPanel.querySelector(`.${styles.detailClose}`)?.addEventListener('click', (e) => {
+          e.stopPropagation();
+          detailPanel.remove();
+        });
+        
+        // 新しい詳細パネルを追加
+        visualization.appendChild(detailPanel);
+      });
+    });
+    
+    // ボリュームセクション
+    const volumes = document.createElement('div');
+    volumes.className = styles.volumes;
+    volumes.innerHTML = `<div class="${styles.sectionTitle}">ボリューム</div>`;
+    
+    const volumesList = document.createElement('div');
+    volumesList.className = styles.volumesList;
+    
+    dockerState.volumes.forEach(volume => {
+      const volumeEl = document.createElement('div');
+      volumeEl.className = styles.volume;
+      volumeEl.innerHTML = `
+        <div class="${styles.volumeIcon}">💾</div>
+        <div class="${styles.volumeLabel}">${volume}</div>
+      `;
+      volumesList.appendChild(volumeEl);
+      
+      // インタラクティブ要素の追加
+      volumeEl.addEventListener('click', () => {
+        const tooltip = document.createElement('div');
+        tooltip.className = styles.tooltip;
+        tooltip.innerHTML = `
+          <div class="${styles.tooltipHeader}">Dockerボリュームとは</div>
+          <div class="${styles.tooltipBody}">
+            <p>Dockerボリュームはコンテナのデータを永続化するための仕組みです。</p>
+            <p>コンテナが削除されても、ボリュームのデータは<span class="${styles.highlight}">保持</span>されます。</p>
+            <p>主な種類:</p>
+            <ul>
+              <li><strong>名前付きボリューム</strong>: Docker管理の永続ボリューム</li>
+              <li><strong>バインドマウント</strong>: ホストのパスを直接マウント</li>
+            </ul>
+          </div>
+        `;
+        
+        // 既存のツールチップを削除
+        const existingTooltips = canvasRef.current?.querySelectorAll(`.${styles.tooltip}`);
+        existingTooltips?.forEach(tip => tip.remove());
+        
+        // 新しいツールチップを追加
+        volumeEl.appendChild(tooltip);
+        
+        // クリックでツールチップを閉じる
+        tooltip.addEventListener('click', (e) => {
+          e.stopPropagation();
+          tooltip.remove();
+        });
+      });
+    });
+    
+    volumes.appendChild(volumesList);
+    
+    // 要素を追加
+    hostMachine.querySelector(`.${styles.hostContent}`)?.appendChild(images);
+    hostMachine.querySelector(`.${styles.hostContent}`)?.appendChild(networks);
+    hostMachine.querySelector(`.${styles.hostContent}`)?.appendChild(containers);
+    hostMachine.querySelector(`.${styles.hostContent}`)?.appendChild(volumes);
+    visualization.appendChild(hostMachine);
+    
+    canvasRef.current.appendChild(visualization);
+    
+    // 関係線を描画する
+    drawRelationshipLines(visualization);
+    
+    // SVG要素を作成して関係線を描画する関数
+    function drawRelationshipLines(parentElement: HTMLElement) {
+      // SVG要素を作成
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      svg.setAttribute('class', styles.relationshipLines);
+      svg.setAttribute('width', '100%');
+      svg.setAttribute('height', '100%');
+      
+      // コンテナ、ネットワーク、ボリュームの要素を取得
+      const containerElements = parentElement.querySelectorAll(`.${styles.container}`);
+      const networkElements = parentElement.querySelectorAll(`.${styles.network}`);
+      const volumeElements = parentElement.querySelectorAll(`.${styles.volume}`);
+      
+      // 関係ごとにラインを描画
+      if (containerElements.length > 0 && (networkElements.length > 0 || volumeElements.length > 0)) {
+        relationships.forEach(rel => {
+          // 要素の座標を取得
+          let fromElement: Element | null = null;
+          let toElement: Element | null = null;
+          
+          // 関係の始点と終点を特定
+          for (const container of containerElements) {
+            if ((container as HTMLElement).dataset.id === rel.from) {
+              fromElement = container;
+              break;
+            }
+          }
+          
+          // 関係の種類に基づいて終点を特定
+          if (rel.type === 'network') {
+            for (const network of networkElements) {
+              if ((network as HTMLElement).dataset.id === `network:${rel.network}`) {
+                toElement = network;
+                break;
+              }
+            }
+          } else if (rel.type === 'volume') {
+            for (const volume of volumeElements) {
+              if ((volume as HTMLElement).dataset.id === `volume:${rel.volume}`) {
+                toElement = volume;
+                break;
+              }
+            }
+          }
+          
+          // 始点と終点が存在する場合は線を描画
+          if (fromElement && toElement) {
+            const fromRect = fromElement.getBoundingClientRect();
+            const toRect = toElement.getBoundingClientRect();
+            const parentRect = parentElement.getBoundingClientRect();
+            
+            // 親要素を基準にした相対座標を計算
+            const fromX = fromRect.left + fromRect.width / 2 - parentRect.left;
+            const fromY = fromRect.top + fromRect.height / 2 - parentRect.top;
+            const toX = toRect.left + toRect.width / 2 - parentRect.left;
+            const toY = toRect.top + toRect.height / 2 - parentRect.top;
+            
+            // パス要素を作成
+            const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+            path.setAttribute('d', `M${fromX},${fromY} Q${fromX},${(fromY + toY) / 2} ${(fromX + toX) / 2},${(fromY + toY) / 2} T${toX},${toY}`);
+            path.setAttribute('class', `${styles.relationshipPath} ${styles[rel.type]}`);
+            
+            // マーカー要素を追加
+            const marker = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+            marker.setAttribute('cx', toX.toString());
+            marker.setAttribute('cy', toY.toString());
+            marker.setAttribute('r', '3');
+            marker.setAttribute('class', `${styles.relationshipMarker} ${styles[rel.type]}`);
+            
+            svg.appendChild(path);
+            svg.appendChild(marker);
+          }
+        });
+        
+        // SVGを親要素に追加
+        if (svg.childNodes.length > 0) {
+          parentElement.appendChild(svg);
+        }
+      }
+    }
+    
+  }, [dockerState]);
+  
+  // 要素クリック時の処理
+  const handleElementClick = (type: 'container' | 'image' | 'network' | 'volume', id: string) => {
+    if (selectedElement.type === type && selectedElement.id === id) {
+      // 同じ要素がクリックされた場合は選択解除
+      setSelectedElement({ type: null, id: null });
+      setVisibleTips([]);
+    } else {
+      // 新しい要素を選択
+      setSelectedElement({ type, id });
+      
+      // 要素に応じた教育用ヒントを表示
+      if (educationalMode) {
+        const tips = getEducationalTipsForElement(type, id);
+        setVisibleTips(tips);
+      }
+    }
+  };
+  
+  // イベントに応じた教育用ヒントを取得
+  const getEducationalTipsForEvent = (
+    elementType: 'container' | 'image' | 'network' | 'volume',
+    eventType: string
+  ): DockerEducationalTip[] => {
+    const tips: DockerEducationalTip[] = [];
+    
+    // コンテナイベント関連のヒント
+    if (elementType === 'container') {
+      if (eventType === 'container_created') {
+        tips.push({
+          id: 'container-create-event',
+          title: 'コンテナの作成',
+          content: 'docker run コマンドでコンテナを作成しました。コンテナはイメージから作成され、独立した環境で実行されます。',
+          elementType: 'container',
+          level: 'beginner'
+        });
+      } else if (eventType === 'container_started') {
+        tips.push({
+          id: 'container-start-event',
+          title: 'コンテナの起動',
+          content: 'コンテナが起動しました。起動中のコンテナはアプリケーションプロセスを実行し、ポートをリッスンしています。',
+          elementType: 'container',
+          level: 'beginner'
+        });
+      } else if (eventType === 'container_stopped') {
+        tips.push({
+          id: 'container-stop-event',
+          title: 'コンテナの停止',
+          content: 'コンテナを停止しました。停止したコンテナはプロセスを終了していますが、ファイルシステムの状態は保持されています。',
+          elementType: 'container',
+          level: 'beginner'
+        });
+      } else if (eventType === 'container_removed') {
+        tips.push({
+          id: 'container-remove-event',
+          title: 'コンテナの削除',
+          content: 'コンテナを削除しました。削除されたコンテナのファイルシステムは破棄されますが、ボリュームのデータは保持されます。',
+          elementType: 'container',
+          level: 'intermediate'
+        });
+      }
+    } else if (elementType === 'network') {
+      if (eventType === 'network_created') {
+        tips.push({
+          id: 'network-create-event',
+          title: 'ネットワークの作成',
+          content: '新しいDockerネットワークが作成されました。ネットワークはコンテナ間の通信を可能にします。',
+          elementType: 'network',
+          level: 'intermediate'
+        });
+      }
+    } else if (elementType === 'volume') {
+      if (eventType === 'volume_created') {
+        tips.push({
+          id: 'volume-create-event',
+          title: 'ボリュームの作成',
+          content: '新しいDockerボリュームが作成されました。ボリュームはコンテナのデータを永続化します。',
+          elementType: 'volume',
+          level: 'intermediate'
+        });
+      }
+    } else if (elementType === 'image') {
+      if (eventType === 'image_pulled') {
+        tips.push({
+          id: 'image-pull-event',
+          title: 'イメージの取得',
+          content: '新しいDockerイメージを取得しました。イメージはコンテナを作成するためのテンプレートです。',
+          elementType: 'image',
+          level: 'beginner'
+        });
+      }
+    }
+    
+    // 難易度レベルに基づきフィルタリング
+    return tips.filter(tip => {
+      if (tip.level === 'beginner') return true;
+      if (tip.level === 'intermediate' && difficultyLevel >= 2) return true;
+      if (tip.level === 'advanced' && difficultyLevel >= 3) return true;
+      return false;
+    });
+  };
+  
+  // 要素に応じた教育用ヒントを取得
+  const getEducationalTipsForElement = (
+    type: 'container' | 'image' | 'network' | 'volume', 
+    id: string
+  ): DockerEducationalTip[] => {
+    const tips: DockerEducationalTip[] = [];
+    
+    // コンテナの教育用ヒント
+    if (type === 'container') {
+      const container = dockerState.containers.find(c => c.id === id);
+      if (container) {
+        // コンテナの基本概念
+        tips.push({
+          id: 'container-basics',
+          title: 'コンテナとは',
+          content: 'コンテナは、アプリケーションとその依存関係を含む軽量な実行環境です。ホストOSのカーネルを共有しながら、独立したプロセス空間を提供します。',
+          elementType: 'container',
+          level: 'beginner'
+        });
+        
+        // VM との違い
+        tips.push({
+          id: 'container-vs-vm',
+          title: 'コンテナとVMの違い',
+          content: 'コンテナはホストOSのカーネルを共有するため、VMよりも軽量で高速です。VMはハードウェアレベルで分離され、独自のOSを持ちます。',
+          elementType: 'container',
+          level: 'beginner'
+        });
+        
+        // ポート関連のヒント
+        if (container.ports.length > 0) {
+          tips.push({
+            id: 'port-mapping',
+            title: 'ポートマッピング',
+            content: 'ホストマシンのポートをコンテナ内のポートにマッピングすることで、外部からのアクセスが可能になります。書式は「ホスト:コンテナ」です。',
+            elementType: 'container',
+            level: 'beginner'
+          });
+        }
+        
+        // ボリューム関連のヒント
+        if (container.volumes.length > 0) {
+          tips.push({
+            id: 'volume-usage',
+            title: 'ボリュームマウント',
+            content: 'ボリュームはコンテナのデータを永続化します。コンテナが削除されても、ボリュームのデータは保持されます。',
+            elementType: 'container',
+            level: 'intermediate'
+          });
+        }
+      }
+    }
+    
+    // ネットワークの教育用ヒント
+    if (type === 'network') {
+      tips.push({
+        id: 'network-basics',
+        title: 'Dockerネットワーク',
+        content: 'Dockerネットワークはコンテナ間の通信を可能にします。同じネットワーク上のコンテナは、コンテナ名で相互にアクセスできます。',
+        elementType: 'network',
+        level: 'beginner'
+      });
+      
+      // ネットワークの種類
+      tips.push({
+        id: 'network-types',
+        title: 'ネットワークの種類',
+        content: 'Dockerには複数のネットワークタイプがあります：bridge（デフォルト）、host（ホストと共有）、none（分離）、overlay（複数ホスト間）など。',
+        elementType: 'network',
+        level: 'intermediate'
+      });
+      
+      // DNS解決のヒント
+      tips.push({
+        id: 'network-dns',
+        title: 'コンテナDNS解決',
+        content: 'Docker内蔵のDNSサーバーにより、同一ネットワーク内のコンテナは名前で互いを検出できます。これによりサービスディスカバリーが容易になります。',
+        elementType: 'network',
+        level: 'intermediate'
+      });
+    }
+    
+    // ボリュームの教育用ヒント
+    if (type === 'volume') {
+      tips.push({
+        id: 'volume-basics',
+        title: 'Dockerボリューム',
+        content: 'ボリュームはDockerコンテナのデータを永続化するための仕組みです。コンテナのライフサイクルとは独立して管理されます。',
+        elementType: 'volume',
+        level: 'beginner'
+      });
+      
+      // ボリュームの種類
+      tips.push({
+        id: 'volume-types',
+        title: 'ボリュームの種類',
+        content: '名前付きボリューム（Docker管理）、バインドマウント（ホストのパス）、tmpfs（メモリ上）の3種類があります。',
+        elementType: 'volume',
+        level: 'intermediate'
+      });
+      
+      // ボリュームのベストプラクティス
+      tips.push({
+        id: 'volume-best-practices',
+        title: 'ボリュームのベストプラクティス',
+        content: 'コンテナ内のデータベースファイル、設定ファイル、アプリケーションデータなどの永続化が必要なデータには必ずボリュームを使用しましょう。また、複数のコンテナで同じデータにアクセスする場合にも有用です。',
+        elementType: 'volume',
+        level: 'advanced'
+      });
+    }
+    
+    // 難易度レベルに基づきフィルタリング
+    return tips.filter(tip => {
+      if (tip.level === 'beginner') return true;
+      if (tip.level === 'intermediate' && difficultyLevel >= 2) return true;
+      if (tip.level === 'advanced' && difficultyLevel >= 3) return true;
+      return false;
+    });
+  };
+  
+  // アニメーション状態に基づくクラス名を生成
+  const getAnimationClassName = (elementType: string, elementId: string): string => {
+    if (!animationState.isAnimating) return '';
+    if (animationState.targetId && animationState.targetId !== elementId) return '';
+    
+    switch (animationState.type) {
+      case 'container_created':
+        return elementType === 'container' ? styles.animateCreate : '';
+      case 'container_started':
+        return elementType === 'container' ? styles.animateStart : '';
+      case 'container_stopped':
+        return elementType === 'container' ? styles.animateStop : '';
+      case 'container_removed':
+        return elementType === 'container' ? styles.animateRemove : '';
+      case 'network_created':
+        return elementType === 'network' ? styles.animateCreate : '';
+      case 'network_removed':
+        return elementType === 'network' ? styles.animateRemove : '';
+      case 'volume_created':
+        return elementType === 'volume' ? styles.animateCreate : '';
+      case 'volume_removed':
+        return elementType === 'volume' ? styles.animateRemove : '';
+      case 'image_pulled':
+        return elementType === 'image' ? styles.animateCreate : '';
+      case 'image_removed':
+        return elementType === 'image' ? styles.animateRemove : '';
+      default:
+        return '';
+    }
+  };
+  
+  // コンポーネントのアンマウント時にタイマーをクリア
+  useEffect(() => {
+    return () => {
+      if (animationTimerRef.current) {
+        clearTimeout(animationTimerRef.current);
+      }
+    };
+  }, []);
+
+  return (
+    <div className={styles.dockerVisualizer}>
+      <motion.h2 
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
+      >
+        Docker環境可視化
+      </motion.h2>
+      
+      <motion.div 
+        className={styles.description}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.2, duration: 0.5 }}
+      >
+        Dockerコンテナ、ネットワーク、ボリュームの関係をビジュアル化して確認できます。
+        要素をクリックすると詳細が表示されます。
+      </motion.div>
+      
+      {/* DIVベースの可視化（非React）は保持しつつ、アニメーション用のオーバーレイを追加 */}
+      <div className={styles.canvasWrapper}>
+        <div className={styles.canvas} ref={canvasRef}></div>
+        
+        {/* アニメーションオーバーレイ */}
+        {showAnimations && animationState.isAnimating && (
+          <motion.div 
+            className={styles.animationOverlay}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.3 }}
+          >
+            <div className={styles.animationStatus}>
+              {animationState.type === 'container_created' && '新しいコンテナを作成中...'}
+              {animationState.type === 'container_started' && 'コンテナを起動中...'}
+              {animationState.type === 'container_stopped' && 'コンテナを停止中...'}
+              {animationState.type === 'container_removed' && 'コンテナを削除中...'}
+              {animationState.type === 'network_created' && '新しいネットワークを作成中...'}
+              {animationState.type === 'network_removed' && 'ネットワークを削除中...'}
+              {animationState.type === 'volume_created' && '新しいボリュームを作成中...'}
+              {animationState.type === 'volume_removed' && 'ボリュームを削除中...'}
+              {animationState.type === 'image_pulled' && '新しいイメージを取得中...'}
+              {animationState.type === 'image_removed' && 'イメージを削除中...'}
+            </div>
+            <motion.div 
+              className={styles.progressBar}
+              initial={{ width: '0%' }}
+              animate={{ width: '100%' }}
+              transition={{ duration: 0.5 }}
+            />
+          </motion.div>
+        )}
+      </div>
+      
+      {/* 凡例 */}
+      <motion.div 
+        className={styles.legend}
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.4, duration: 0.5 }}
+      >
+        <div className={styles.legendItem}>
+          <div className={`${styles.legendSymbol} ${styles.runningLegend}`}></div>
+          <span>実行中のコンテナ</span>
+        </div>
+        <div className={styles.legendItem}>
+          <div className={`${styles.legendSymbol} ${styles.exitedLegend}`}></div>
+          <span>停止したコンテナ</span>
+        </div>
+        <div className={styles.legendItem}>
+          <div className={`${styles.legendSymbol} ${styles.createdLegend}`}></div>
+          <span>作成済みコンテナ</span>
+        </div>
+        <div className={styles.legendItem}>
+          <div className={`${styles.legendSymbol} ${styles.volumeLegend}`}></div>
+          <span>ボリューム</span>
+        </div>
+        <div className={styles.legendItem}>
+          <div className={`${styles.legendSymbol} ${styles.networkLegend}`}></div>
+          <span>ネットワーク</span>
+        </div>
+      </motion.div>
+      
+      {/* 教育用ヒント */}
+      <AnimatePresence>
+        {visibleTips.length > 0 && (
+          <motion.div 
+            className={styles.activeTips}
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -20 }}
+            transition={{ duration: 0.3 }}
+          >
+            <div className={styles.tipsHeader}>
+              <h3>Docker知識: {selectedElement.type || visibleTips[0].elementType}</h3>
+              <button 
+                className={styles.closeTips}
+                onClick={() => {
+                  setVisibleTips([]);
+                  if (animationTimerRef.current) {
+                    clearTimeout(animationTimerRef.current);
+                    animationTimerRef.current = null;
+                  }
+                }}
+              >
+                閉じる
+              </button>
+            </div>
+            <div className={styles.tipsList}>
+              {visibleTips.map((tip) => (
+                <motion.div 
+                  key={tip.id}
+                  className={styles.tipItem}
+                  initial={{ opacity: 0, x: -10 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  transition={{ duration: 0.3 }}
+                >
+                  <h4>{tip.title}</h4>
+                  <p>{tip.content}</p>
+                </motion.div>
+              ))}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+      
+      {/* 基本的な教育コンテンツ */}
+      <motion.div 
+        className={styles.educationTips}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.6, duration: 0.5 }}
+      >
+        <h3>Docker基礎知識</h3>
+        <ul>
+          <li>
+            <strong>コンテナ</strong>: 
+            アプリケーションとその依存関係を一緒にパッケージ化したもの。
+            ホストOSのカーネルを共有しながら、分離された実行環境を提供します。
+          </li>
+          <li>
+            <strong>イメージ</strong>: 
+            コンテナの実行に必要なファイルシステムのスナップショット。
+            読み取り専用で、コンテナはこれをもとに実行されます。
+          </li>
+          <li>
+            <strong>ポートマッピング</strong>: 
+            ホストマシンのポートからコンテナのポートへのリダイレクト。
+            外部からコンテナ内のサービスにアクセスするために使用します。
+          </li>
+          <li>
+            <strong>ボリューム</strong>: 
+            コンテナのデータを永続化するための仕組み。
+            コンテナのライフサイクルとは独立してデータを保持できます。
+          </li>
+          <li>
+            <strong>ネットワーク</strong>: 
+            コンテナ間の通信を可能にするための仮想ネットワーク。
+            同じネットワーク内のコンテナはコンテナ名で相互通信できます。
+          </li>
+        </ul>
+      </motion.div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要
Issue #48に関連して、Docker学習体験のためのコアコンポーネントを追加します。これらのコンポーネントは、すでにマージされた[PR #65](https://github.com/shiftrepo/aws/pull/65)で追加されたDocker学習ページとの連携を強化します。

## 変更内容
以下のDockerコンポーネントを追加しました：

### 主要コンポーネント
- **DockerVisualizer**: 
  - コンテナ、イメージ、レイヤーなどの視覚的表現
  - インタラクティブなアニメーションによる状態変化の可視化

- **DockerTerminal**: 
  - DockerコマンドCLIシミュレーター
  - コマンド入力と出力表示機能

- **DockerGuide**:
  - 学習コンテンツとガイドコンポーネント
  - ステップバイステップの学習パス

- **DockerSimulator**:
  - Dockerコマンドのシミュレーション実行
  - 状態管理とイベント発行

### 補助コンポーネント
- DockerTypes: 型定義
- DockerEventEmitter: イベント通知システム
- DockerLearningContext: 状態共有用Reactコンテキスト
- DockerChallenges: インタラクティブな課題
- DefaultDocker: デフォルト設定と初期状態

## 関連Issue
補完: Issue #48

## テスト方法
1. Docker学習ページ（`/docker-learning`）にアクセス
2. 「インタラクティブデモ」タブを開く
3. Dockerコマンドを入力して動作確認
4. 視覚的なコンテナ表示とコマンド実行の連携を確認

## スクリーンショット
（実際の環境ではスクリーンショットを添付）

## 注意事項
このPRは主にコンポーネントの追加のみで、既存PR #65で作成された基本的なUIとの統合が次のステップとなります。