### PR TITLE
Docker学習コンテンツのJSX構文エラーの修正

### DIFF
--- a/container/claudecode/studyGIt/src/pages/docker-learning.js
+++ b/container/claudecode/studyGIt/src/pages/docker-learning.js
@@ -225,7 +225,7 @@ export default function DockerLearning() {
                 <p>$ docker ps</p>
                 <p className={styles.terminalOutput}>
                 CONTAINER ID   IMAGE   COMMAND                  CREATED         STATUS         PORTS                NAMES<br/>
-                a7f3s9d8       nginx   "/docker-entrypoint.…"   5 seconds ago   Up 4 seconds   0.0.0.0:80->80/tcp   inspiring_edison
+                a7f3s9d8       nginx   "/docker-entrypoint.…"   5 seconds ago   Up 4 seconds   0.0.0.0:80{'->'}80/tcp   inspiring_edison
                 </p>
                 <p>$ docker exec -it a7f3s9d8 /bin/bash</p>
                 <p>root@a7f3s9d8:/# ls</p>


### PR DESCRIPTION
## 概要
Docker学習ページ（`src/pages/docker-learning.js`）内のJSX構文エラーを修正しました。

## 修正内容
- Docker PS出力のポート転送表示（`0.0.0.0:80->80/tcp`）にあった `>` 記号がJSXの閉じタグと誤解釈されていた問題を修正
- 問題の箇所を `{'->'}` に置き換えてJSXとして正しく解釈されるように修正

## テスト方法
1. `npm run build` を実行して、ビルドエラーが発生しないことを確認
2. `npm run dev` を実行して、Docker学習ページが正しく表示されることを確認

## 関連Issue
修正内容はDockerコンテンツに関連するIssue #48に関係します

## スクリーンショット
なし（構文エラーの修正のため）