### PR TITLE
Podmanサポートの追加とコンテナ環境の改善

### DIFF
--- a/container/claudecode/forpasipde/.env
+++ b/container/claudecode/forpasipde/.env
@@ -1,0 +1,10 @@
+# Bedrockを使う設定
+export CLAUDE_CODE_USE_BEDROCK=1
+
+# Amazon Bedrock (モデルIDを使用)
+ANTHROPIC_MODEL=us.anthropic.claude-sonnet-4-20250514-v1:0
+ANTHROPIC_SMALL_FAST_MODEL=us.anthropic.claude-3-5-haiku-20241022-v1:0
+
+# プロンプトキャッシングを有効にできない場合の設定 ※
+#export DISABLE_PROMPT_CACHING=1
+

--- a/container/claudecode/forpasipde/.env
+++ b/container/claudecode/forpasipde/.env
@@ -1,10 +1,42 @@
-# Bedrockを使う設定
-export CLAUDE_CODE_USE_BEDROCK=1
+# Claude Code実行環境 - 環境変数設定例
+# このファイルを .env にコピーして使用してください
+# cp .env.example .env
 
-# Amazon Bedrock (モデルIDを使用)
+# ===========================================
+# Claude Code基本設定
+# ===========================================
+
+# Bedrockを使用するかどうか (1: 使用, 0: 使用しない)
+CLAUDE_CODE_USE_BEDROCK=1
+
+# 使用するメインモデル（Amazon Bedrock モデルID）
 ANTHROPIC_MODEL=us.anthropic.claude-sonnet-4-20250514-v1:0
+
+# 使用する小型高速モデル（Amazon Bedrock モデルID）
 ANTHROPIC_SMALL_FAST_MODEL=us.anthropic.claude-3-5-haiku-20241022-v1:0
 
-# プロンプトキャッシングを有効にできない場合の設定 ※
-#export DISABLE_PROMPT_CACHING=1
+# プロンプトキャッシングを無効にする場合（コメントアウトを外す）
+#DISABLE_PROMPT_CACHING=1
 
+# ===========================================
+# AWS認証設定（Amazon Bedrock使用時に必要）
+# ===========================================
+
+# AWSアクセスキー
+AWS_ACCESS_KEY_ID=YOUR_AWS_ACCESS_KEY_ID
+
+# AWSシークレットキー  
+AWS_SECRET_ACCESS_KEY=YOUR_AWS_SECRET_ACCESS_KEY
+
+# AWSリージョン
+AWS_REGION=us-east-1
+
+# ===========================================
+# GitLab MCP設定
+# ===========================================
+
+# GitLab APIアクセストークン
+GITLAB_API_TOKEN=YOUR_GITLAB_API_TOKEN
+
+# GitLabホスト（通常は変更不要）
+GITLAB_HOST=gitlab.local

--- a/container/claudecode/forpasipde/.env.example
+++ b/container/claudecode/forpasipde/.env.example
@@ -1,0 +1,12 @@
+# Amazon Bedrock設定
+CLAUDE_CODE_USE_BEDROCK=1
+ANTHROPIC_MODEL=us.anthropic.claude-3-7-sonnet-20250219-v1:0
+ANTHROPIC_SMALL_FAST_MODEL=us.anthropic.claude-3-5-haiku-20241022-v1:0
+
+# AWS認証情報
+AWS_ACCESS_KEY_ID=your_access_key
+AWS_SECRET_ACCESS_KEY=your_secret_key
+AWS_REGION=us-east-1
+
+# GitLabトークン
+GITLAB_API_TOKEN=your_gitlab_token

--- a/container/claudecode/forpasipde/.env.example
+++ b/container/claudecode/forpasipde/.env.example
@@ -1,12 +1,43 @@
-# Amazon Bedrock設定
+# Claude Code実行環境 - 環境変数設定例
+# このファイルを .env にコピーして使用してください
+# cp .env.example .env
+
+# ===========================================
+# Claude Code基本設定
+# ===========================================
+
+# Bedrockを使用するかどうか (1: 使用, 0: 使用しない)
 CLAUDE_CODE_USE_BEDROCK=1
-ANTHROPIC_MODEL=us.anthropic.claude-3-7-sonnet-20250219-v1:0
+
+# 使用するメインモデル（Amazon Bedrock モデルID）
+ANTHROPIC_MODEL=us.anthropic.claude-sonnet-4-20250514-v1:0
+
+# 使用する小型高速モデル（Amazon Bedrock モデルID）
 ANTHROPIC_SMALL_FAST_MODEL=us.anthropic.claude-3-5-haiku-20241022-v1:0
 
-# AWS認証情報
-AWS_ACCESS_KEY_ID=your_access_key
-AWS_SECRET_ACCESS_KEY=your_secret_key
+# プロンプトキャッシングを無効にする場合（コメントアウトを外す）
+#DISABLE_PROMPT_CACHING=1
+
+# ===========================================
+# AWS認証設定（Amazon Bedrock使用時に必要）
+# ===========================================
+
+# AWSアクセスキー
+AWS_ACCESS_KEY_ID=YOUR_AWS_ACCESS_KEY_ID
+
+# AWSシークレットキー  
+AWS_SECRET_ACCESS_KEY=YOUR_AWS_SECRET_ACCESS_KEY
+
+# AWSリージョン
 AWS_REGION=us-east-1
 
-# GitLabトークン
-GITLAB_API_TOKEN=your_gitlab_token
+# ===========================================
+# GitLab MCP設定
+# ===========================================
+
+# GitLab APIアクセストークン
+GITLAB_API_TOKEN=YOUR_GITLAB_API_TOKEN
+
+# GitLabホスト（通常は変更不要）
+GITLAB_HOST=gitlab.local
+EOF < /dev/null

--- a/container/claudecode/forpasipde/CLAUDE.md
+++ b/container/claudecode/forpasipde/CLAUDE.md
@@ -1,0 +1,146 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## コンテナ環境の構成
+
+このリポジトリはClaude Codeを実行するための複数ベースイメージに対応したDockerコンテナ環境を提供します。主な構成要素：
+
+- 複数のベースイメージサポート（Node.js slim、Debian slim、Amazon Linux 2023）
+- GitLabをMCPサーバーとして導入
+- SELinux対応のボリュームマウント（:z共有モード）
+- 段階的実装計画による優先順位対応
+
+## コマンド一覧
+
+### 環境のセットアップと起動
+
+```bash
+# 環境変数の設定
+cp .env.example .env
+# .envファイルを編集して必要な値を設定
+
+# ベースイメージを指定してコンテナを起動
+./run.sh           # Node.js slim版を起動（デフォルト）
+./run.sh node      # Node.js slim版を起動
+./run.sh debian    # Debian slim版を起動
+./run.sh amazonlinux # Amazon Linux版を起動
+
+# 従来のdocker-compose直接実行
+docker-compose up -d                           # 現在のdocker-compose.yml使用
+docker-compose -f docker-compose-node.yml up -d    # Node.js版（予定）
+docker-compose -f docker-compose-debian.yml up -d  # Debian版（予定）
+
+# コンテナのログを確認
+docker-compose logs -f
+
+# 起動中のコンテナに接続
+docker-compose exec claudecode bash
+```
+
+### Claude Codeの設定と実行
+
+```bash
+# GitLab MCPのセットアップ（コンテナ内で実行）
+./setup_gitlab_mcp.sh
+
+# Claude Codeのバージョン確認
+claude --version
+
+# MCPの設定確認
+claude mcp list
+
+# GitLab MCPの追加
+envsubst < add_gitlab_mcp.json > add_token_gitlab_mcp.json
+claude mcp add-json gitlab-org "$(cat add_token_gitlab_mcp.json)" --verbose
+rm -f add_token_gitlab_mcp.json
+
+# GitHub MCPの追加（必要な場合）
+envsubst < add_mcp.json > add_token_github_mcp.json
+claude mcp add-json github-org "$(cat add_token_github_mcp.json)" --verbose
+rm -f add_token_github_mcp.json
+
+# Claude Codeの実行
+claude code
+```
+
+## アーキテクチャ概要
+
+この環境は複数のベースイメージをサポートし、以下の主要コンポーネントで構成されています：
+
+### 1. **Claude Code コンテナ（複数バリアント）**:
+
+#### Node.js slim版（最優先実装）:
+   - `node:18-slim`をベースイメージとして使用
+   - Node.jsが既にインストール済み（nvmは基本不要）
+   - 最小限の設定で高速起動
+   - GitLab CLIとMCPサーバーパッケージを導入
+
+#### Debian slim版（中優先実装）:
+   - Debian slimをベースイメージとして使用
+   - APTパッケージマネージャーによる軽量構成
+   - Node.jsとnvmを手動インストール
+
+#### Amazon Linux 2023版（低優先実装）:
+   - Amazon Linux 2023をベースイメージとして使用
+   - DNFパッケージマネージャーによるAWS親和性重視
+   - Node.js 22とnvmをインストール
+
+### 2. **GitLabコンテナ**:
+   - GitLabのCEエディションを使用
+   - MCPサーバーとして機能し、GitLabのAPIを通じてリポジトリアクセスを提供
+   - ボリュームを使用して設定と永続データを保存
+   - APIレート制限設定（300リクエスト/時間）
+
+### 3. **マルチコンテナ構成管理**:
+   - 複数のdocker-compose.ymlファイルによるバリアント管理
+   - 統一された環境変数管理
+   - SELinux対応の:z共有モードボリュームマウント
+
+### 4. **環境変数管理**:
+   - AWS BedrockとAnthropicモデルの設定
+   - GitLab API認証用のトークン管理
+   - 秘匿情報は.envファイルで管理（gitignore対象）
+
+## 必須環境変数
+
+以下の環境変数は.envファイルに設定する必要があります：
+
+- `CLAUDE_CODE_USE_BEDROCK` - Amazon Bedrockを使用するかどうか
+- `ANTHROPIC_MODEL` - 使用するメインモデル
+- `ANTHROPIC_SMALL_FAST_MODEL` - 使用する小型高速モデル
+- `AWS_ACCESS_KEY_ID` - AWSアクセスキー
+- `AWS_SECRET_ACCESS_KEY` - AWSシークレットキー
+- `AWS_REGION` - AWSリージョン
+- `GITLAB_API_TOKEN` - GitLab APIトークン
+
+## 開発ワークフロー
+
+### ベースイメージ選択指針
+
+1. **Node.js slim**: 最もシンプル、Node.js環境が既に整っている場合
+2. **Debian slim**: 軽量性重視、カスタマイズ性が必要な場合
+3. **Amazon Linux**: AWS環境との親和性、エンタープライズ用途
+
+### 実装優先順位
+
+current issue #72の要件により、以下の順序で実装：
+1. Node.js slim版（最優先）
+2. Debian slim版（中優先）
+3. Amazon Linux版（低優先）
+
+## GitHubからGitLabへの移行について
+
+このリポジトリでは、GitHub MCPからGitLab MCPへの移行を実施中です：
+
+### 主な変更点:
+1. 環境変数: `GITHUB_PERSONAL_ACCESS_TOKEN` → `GITLAB_PERSONAL_ACCESS_TOKEN`
+2. プルリクエスト名: Pull Request (PR) → Merge Request (MR)
+3. MCPパッケージ: `@modelcontextprotocol/server-github` → `@modelcontextprotocol/server-gitlab`
+
+### 移行手順:
+1. GitLabアカウントでAPIトークンを生成
+2. `GITLAB_API_TOKEN`環境変数を設定
+3. `./setup_gitlab_mcp.sh`でGitLab MCPをセットアップ
+
+詳細は`github_to_gitlab_mcp_migration.md`と`gitlab_mcp_implementation_plan.md`を参照してください。

--- a/container/claudecode/forpasipde/README.md
+++ b/container/claudecode/forpasipde/README.md
@@ -46,3 +46,4 @@ forpasipde/
 - `AWS_SECRET_ACCESS_KEY` - AWSシークレットキー
 - `AWS_REGION` - AWSリージョン
 - `GITLAB_API_TOKEN` - GitLab APIトークン
+

--- a/container/claudecode/forpasipde/README.md
+++ b/container/claudecode/forpasipde/README.md
@@ -1,0 +1,48 @@
+# Claude Code実行環境
+
+このディレクトリには、Claude Codeを実行するためのDockerコンテナ環境のファイルが含まれています。
+GitLabをMCPサーバーとして導入し、GitHub MCPからGitLab MCPへの変更を行っています。
+
+## ディレクトリ構成
+
+```
+forpasipde/
+├── amazonlinux.Dockerfile    # Claude Code用のDockerfile
+├── docker-compose.yml        # Docker Compose設定ファイル
+├── add_gitlab_mcp.json       # GitLab MCP設定用JSONファイル
+├── add_mcp.json              # MCP設定用JSONファイル
+├── setup.sh                  # セットアップスクリプト
+├── .env.example              # 環境変数設定例
+├── run.sh                    # 起動スクリプト
+└── workdir/                  # 作業ディレクトリ（ボリュームマウント用）
+```
+
+## セットアップ方法
+
+1. 環境変数の設定
+   ```bash
+   cp .env.example .env
+   # .envファイルを編集して必要な設定を行う
+   ```
+
+2. コンテナの起動
+   ```bash
+   ./run.sh
+   ```
+
+## 主な機能
+
+- Claude Codeの実行環境（Node.js 22、nvm）
+- GitLabコンテナの導入とMCPサーバーとしての設定
+- SELinux対応の:z共有モードによるボリュームマウント
+- GitHub MCPからGitLab MCPへの変更
+
+## 環境変数
+
+- `CLAUDE_CODE_USE_BEDROCK` - Amazon Bedrockを使用するかどうか
+- `ANTHROPIC_MODEL` - 使用するメインモデル
+- `ANTHROPIC_SMALL_FAST_MODEL` - 使用する小型高速モデル
+- `AWS_ACCESS_KEY_ID` - AWSアクセスキー
+- `AWS_SECRET_ACCESS_KEY` - AWSシークレットキー
+- `AWS_REGION` - AWSリージョン
+- `GITLAB_API_TOKEN` - GitLab APIトークン

--- a/container/claudecode/forpasipde/add_gitlab_mcp.json
+++ b/container/claudecode/forpasipde/add_gitlab_mcp.json
@@ -1,0 +1,7 @@
+{
+  "command": "npx",
+  "args": ["-y", "@modelcontextprotocol/server-gitlab"],
+  "env": {
+    "GITLAB_PERSONAL_ACCESS_TOKEN": "${GITLAB_API_TOKEN}"
+  }
+}

--- a/container/claudecode/forpasipde/add_mcp.json
+++ b/container/claudecode/forpasipde/add_mcp.json
@@ -1,0 +1,7 @@
+{
+  "command": "npx",
+  "args": ["-y", "@modelcontextprotocol/server-github"],
+  "env": {
+    "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_SHIFTREPO_PAT}"
+  }
+}

--- a/container/claudecode/forpasipde/amazonlinux.Dockerfile
+++ b/container/claudecode/forpasipde/amazonlinux.Dockerfile
@@ -1,0 +1,58 @@
+FROM amazonlinux:2023
+
+# 必要なパッケージのインストール
+RUN dnf update -y \
+    && dnf install -y \
+    nodejs \
+    npm \
+    git \
+    curl \
+    wget \
+    tar \
+    gzip \
+    unzip \
+    which \
+    procps \
+    shadow-utils \
+    && dnf clean all
+
+# nvmのインストール
+ENV NVM_DIR /usr/local/nvm
+RUN mkdir -p $NVM_DIR
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash
+
+# nvmセットアップのためのシェル設定
+RUN echo 'export NVM_DIR="/usr/local/nvm"' >> /etc/profile.d/nvm.sh \
+    && echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> /etc/profile.d/nvm.sh
+
+# GitLab CLIのインストール（オプション）
+RUN curl -s https://packages.gitlab.com/install/repositories/gitlab/gitlab-ee/script.rpm.sh | bash \
+    && dnf install -y gitlab-cli \
+    && dnf clean all
+
+# 専用ユーザーの作成
+RUN useradd -ms /bin/bash appuser
+
+# 作業ディレクトリの設定
+WORKDIR /app
+
+# アプリケーションのファイルをコピー
+COPY package*.json ./
+
+# 依存関係のインストール
+RUN npm install
+
+# 残りのアプリケーションコードをコピー
+COPY . .
+
+# アプリケーションディレクトリの所有者を変更
+RUN chown -R appuser:appuser /app
+
+# アプリケーションユーザーに切り替え
+USER appuser
+
+# アプリケーションのポート公開
+EXPOSE 3000
+
+# 起動コマンド
+CMD ["npm", "start"]

--- a/container/claudecode/forpasipde/base-image-analysis.txt
+++ b/container/claudecode/forpasipde/base-image-analysis.txt
@@ -1,0 +1,140 @@
+# Claude Code用Dockerfileベースイメージ分析
+
+## 調査目的
+Claude Codeに最適なDockerfileのベースイメージを選定するための分析を行う。要件として、Node.jsとnvmのサポート、およびGitLab連携の対応が必要。
+
+## 調査対象ベースイメージ
+1. Amazon Linux 2023
+2. Ubuntu
+3. Debian
+4. Node.js公式イメージ（各ディストリビューションベース）
+
+## 各ベースイメージの分析
+
+### 1. Amazon Linux 2023
+- **特徴**：
+  - AWSが開発・サポートする軽量Linuxディストリビューション
+  - RPMベースのパッケージ管理（dnf）
+  - AWSサービスとの親和性が高い
+  - セキュリティアップデートとパッチの定期提供（2029年6月30日までサポート）
+- **Node.js/nvm対応**：
+  - 標準リポジトリからNode.jsインストール可能
+  - nvmは公式リポジトリにないため、スクリプトからインストール必要
+  - DNFによるパッケージ管理が容易
+- **GitLab対応**：
+  - Git: 公式リポジトリから最新バージョン入手可能
+  - GitLabインテグレーション: GitLab Runner等の連携ツールが利用可能
+- **サイズ**：他のベースイメージと比較して中程度
+- **その他**：
+  - AWSインフラ上で動作する場合との整合性が高い
+
+### 2. Ubuntu
+- **特徴**：
+  - 広く採用されている汎用Linuxディストリビューション
+  - Debianベースのパッケージ管理（apt）
+  - コミュニティサポートが充実
+  - LTSバージョンは長期サポート（5年間）
+- **Node.js/nvm対応**：
+  - 標準リポジトリ、PPAなど複数の入手方法
+  - nvmのインストールが容易
+  - aptによるパッケージ管理の利便性
+- **GitLab対応**：
+  - Git: 標準で提供、バージョンアップも容易
+  - GitLab連携ツールのドキュメントが充実
+- **サイズ**：標準イメージはAmazon Linuxより若干大きい
+- **その他**：
+  - 開発環境として広く利用されており、情報が豊富
+
+### 3. Debian
+- **特徴**：
+  - 安定性に定評のあるLinuxディストリビューション
+  - aptによるパッケージ管理
+  - 最小構成で構築可能（slim版）
+  - セキュリティアップデートの提供
+- **Node.js/nvm対応**：
+  - 標準リポジトリからNode.jsインストール可能
+  - nvmのインストールも容易
+  - バージョン管理の柔軟性
+- **GitLab対応**：
+  - Git: 安定版の提供
+  - GitLab連携のためのパッケージ対応
+- **サイズ**：slim版を使用すると最も小さい
+- **その他**：
+  - 多くのコンテナベースイメージの元になっている
+
+### 4. Node.js公式イメージ
+- **特徴**：
+  - Node.js実行環境が予めセットアップ済み
+  - 様々なNode.jsバージョンから選択可能
+  - 異なるベースイメージバリアントが存在（alpine, slim, bullseye等）
+- **Node.js/nvm対応**：
+  - Node.jsが既にインストール済み（nvmは不要）
+  - 特定バージョンの指定が容易
+- **GitLab対応**：
+  - 追加でGitのインストールが必要
+  - GitLab連携ツールを別途インストール必要
+- **サイズ**：
+  - フルバージョン: 比較的大きい
+  - Alpine版: 最小サイズ
+  - Slim版: 中間サイズ
+
+## 推奨ベースイメージの選定
+
+以下の観点から最適なベースイメージを選定します：
+
+1. **開発の容易さと安定性**: Ubuntuが最も情報が豊富で開発しやすい
+2. **サイズ効率**: Debian slimまたはAlpineベースが最も軽量
+3. **AWSとの親和性**: Amazon Linux 2023がAWSサービスとの連携が最も良い
+4. **Node.js対応**: Node.js公式イメージが最も設定が少なく済む
+
+### 最終推奨
+
+**1. 本番環境向け: Node.js公式イメージ（Alpine or Debian slim）**
+```dockerfile
+FROM node:18-slim
+
+# GitLab連携に必要なパッケージ
+RUN apt-get update && apt-get install -y git curl
+
+# 必要に応じてnvmをインストール
+# RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash
+
+WORKDIR /app
+# 以下アプリケーション依存の設定
+```
+
+**2. AWS環境との親和性重視: Amazon Linux 2023**
+```dockerfile
+FROM amazonlinux:2023
+
+# Node.jsとnvmのインストール
+RUN dnf install -y nodejs npm git
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash
+
+WORKDIR /app
+# 以下アプリケーション依存の設定
+```
+
+**3. 開発環境向け: Ubuntu**
+```dockerfile
+FROM ubuntu:22.04
+
+# 基本パッケージのインストール
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    nodejs \
+    npm
+
+# nvmのインストール
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash
+
+WORKDIR /app
+# 以下アプリケーション依存の設定
+```
+
+## 結論
+
+Claude Codeの要件を考慮すると、Node.js公式イメージの**Debian slim**または**Alpine**ベースを推奨します。特に本番環境では軽量で必要な機能が揃ったSlimイメージが適しています。開発環境では情報が豊富なUbuntuベースも選択肢になります。AWSサービスと深く連携する場合はAmazon Linux 2023も検討すべきです。
+
+いずれの選択においても、GitLab連携のためにGitは必ず含め、Node.jsのバージョン管理が必要な場合はnvmも追加することで要件を満たせます。

--- a/container/claudecode/forpasipde/docker-base-image-usage.md
+++ b/container/claudecode/forpasipde/docker-base-image-usage.md
@@ -1,0 +1,198 @@
+# Claude Codeのためのベースイメージ使用ガイド
+
+このドキュメントでは、Claude Codeアプリケーション用に作成された各ベースイメージの使い方とカスタマイズ方法について説明します。
+
+## 提供されるDockerfile
+
+以下の4つのDockerfileを用意しています：
+
+1. `node-slim.Dockerfile` - Debian slimベースのNode.jsイメージ
+2. `node-alpine.Dockerfile` - Alpineベースの軽量Node.jsイメージ
+3. `amazonlinux.Dockerfile` - Amazon Linux 2023ベースのイメージ
+4. `ubuntu.Dockerfile` - Ubuntu 22.04ベースのイメージ
+
+## ビルド方法
+
+各Dockerfileをビルドするには、以下のコマンドを使用します：
+
+```bash
+# Node.js (Debian slim) イメージのビルド
+docker build -t claudecode:node-slim -f node-slim.Dockerfile .
+
+# Node.js (Alpine) イメージのビルド
+docker build -t claudecode:alpine -f node-alpine.Dockerfile .
+
+# Amazon Linux イメージのビルド
+docker build -t claudecode:amazonlinux -f amazonlinux.Dockerfile .
+
+# Ubuntu イメージのビルド
+docker build -t claudecode:ubuntu -f ubuntu.Dockerfile .
+```
+
+## イメージの選択ガイド
+
+各イメージの使用シナリオとメリットを以下に示します：
+
+### 1. Node.js (Debian slim)
+- **適したシナリオ**: 本番環境、バランスの取れたパフォーマンスと機能性が必要な場合
+- **メリット**: 
+  - 比較的小さいイメージサイズ
+  - 必要十分なツールセット
+  - 安定性と互換性のバランスが良い
+- **推奨環境**: 一般的な本番環境、CI/CDパイプライン
+
+### 2. Node.js (Alpine)
+- **適したシナリオ**: リソースが限られた環境、最小限のイメージサイズが必要な場合
+- **メリット**:
+  - 非常に小さいイメージサイズ
+  - 起動時間の短縮
+  - セキュリティ面の利点（攻撃対象領域の削減）
+- **推奨環境**: Kubernetesクラスタ、マイクロサービス環境、IoTデバイス
+
+### 3. Amazon Linux 2023
+- **適したシナリオ**: AWS環境での運用、AWSサービスとの深い連携
+- **メリット**:
+  - AWSサービスとの互換性
+  - 長期サポート (2029年まで)
+  - AWSツールチェーンとの統合が容易
+- **推奨環境**: AWS ECS、AWS EKS、EC2インスタンス
+
+### 4. Ubuntu 22.04
+- **適したシナリオ**: 開発環境、広いエコシステムが必要な場合
+- **メリット**:
+  - 豊富なドキュメントとコミュニティサポート
+  - 広い互換性
+  - 開発ツールの充実
+- **推奨環境**: 開発環境、テスト環境
+
+## カスタマイズ方法
+
+### Node.jsバージョンのカスタマイズ
+
+ベースイメージのNode.jsバージョンを変更する場合は、Dockerfileの最初の行を変更します：
+
+```dockerfile
+# 例: Node.js 20 を使用したい場合
+FROM node:20-slim
+# または
+FROM node:20-alpine
+```
+
+### nvmを使用したNode.jsバージョン管理
+
+nvmを使ってNode.jsのバージョンを切り替える場合：
+
+```bash
+# コンテナ内で特定のNode.jsバージョンをインストール
+source /etc/profile.d/nvm.sh
+nvm install 16
+nvm use 16
+```
+
+Dockerfileでこれを自動化する場合：
+
+```dockerfile
+# 特定のNode.jsバージョンを自動的にインストール
+RUN source $NVM_DIR/nvm.sh \
+    && nvm install 16 \
+    && nvm alias default 16 \
+    && nvm use default
+```
+
+### 追加パッケージのインストール
+
+#### Debian/Ubuntu系
+
+```dockerfile
+RUN apt-get update && apt-get install -y \
+    package1 \
+    package2 \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+#### Alpine系
+
+```dockerfile
+RUN apk add --no-cache \
+    package1 \
+    package2
+```
+
+#### Amazon Linux系
+
+```dockerfile
+RUN dnf install -y \
+    package1 \
+    package2 \
+    && dnf clean all
+```
+
+### GitLab連携のカスタマイズ
+
+GitLabとの連携を強化したい場合、以下の設定を追加できます：
+
+```dockerfile
+# GitLab Runner のインストール
+RUN curl -L "https://packages.gitlab.com/install/repositories/runner/gitlab-runner/script.deb.sh" | bash \
+    && apt-get update \
+    && apt-get install -y gitlab-runner \
+    && rm -rf /var/lib/apt/lists/*
+
+# GitLab CI 環境変数の設定
+ENV CI_SERVER_URL="https://gitlab.example.com"
+ENV CI_REGISTRY="registry.example.com"
+```
+
+## セキュリティ対策
+
+セキュリティを強化するためのベストプラクティス：
+
+1. **非rootユーザーの使用**: 既にDockerfileに含まれています
+2. **最小権限の原則**: 必要なアクセス権のみを付与
+3. **マルチステージビルド**: 本番イメージを小さく保つ
+
+マルチステージビルドの例：
+
+```dockerfile
+# ビルドステージ
+FROM node:18-slim as builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+# 本番ステージ
+FROM node:18-slim
+WORKDIR /app
+COPY --from=builder /app/build ./build
+COPY --from=builder /app/node_modules ./node_modules
+COPY package*.json ./
+USER appuser
+CMD ["npm", "start"]
+```
+
+## トラブルシューティング
+
+一般的な問題と解決策：
+
+1. **nvmコマンドが見つからない**:
+   ```bash
+   source /etc/profile.d/nvm.sh
+   ```
+
+2. **パッケージのインストールエラー**:
+   - Debianベース: `apt-get update`の実行
+   - Alpine: 必要なビルドツールの追加 `apk add --no-cache build-base python3`
+   - Amazon Linux: `dnf update`の実行
+
+3. **パーミッションエラー**:
+   ```bash
+   chown -R appuser:appuser /問題のディレクトリ
+   ```
+
+## 結論
+
+Claude Codeの要件に基づいて、本番環境には`node-slim.Dockerfile`または`node-alpine.Dockerfile`をお勧めします。AWS環境では`amazonlinux.Dockerfile`、開発環境では`ubuntu.Dockerfile`が最適です。
+
+特定のニーズに合わせてこれらのDockerfileをカスタマイズし、必要に応じて追加のツールや設定を組み込んでください。

--- a/container/claudecode/forpasipde/docker-compose-amazonlinux.yml
+++ b/container/claudecode/forpasipde/docker-compose-amazonlinux.yml
@@ -1,0 +1,64 @@
+version: '3.8'
+
+services:
+  claudecode-amazonlinux:
+    build:
+      context: .
+      dockerfile: amazonlinux.Dockerfile
+    container_name: claude-code-amazonlinux
+    volumes:
+      - ./.env:/.env:ro  # 環境変数ファイルをマウント（読み取り専用）
+      - ./workdir:/app/workdir:z  # 作業ディレクトリをマウント（SELinuxラベル共有モード）
+      - ./add_gitlab_mcp.json:/app/add_gitlab_mcp.json:z  # GitLab MCP設定ファイル
+      - ./add_mcp.json:/app/add_mcp.json:z  # MCP設定ファイル
+    environment:
+      - CLAUDE_CODE_USE_BEDROCK=${CLAUDE_CODE_USE_BEDROCK:-1}
+      - ANTHROPIC_MODEL=${ANTHROPIC_MODEL:-us.anthropic.claude-sonnet-4-20250514-v1:0}
+      - ANTHROPIC_SMALL_FAST_MODEL=${ANTHROPIC_SMALL_FAST_MODEL:-us.anthropic.claude-3-5-haiku-20241022-v1:0}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_REGION=${AWS_REGION:-us-east-1}
+      - GITLAB_API_TOKEN=${GITLAB_API_TOKEN}
+      - GITLAB_PERSONAL_ACCESS_TOKEN=${GITLAB_API_TOKEN}
+    tty: true
+    stdin_open: true
+    restart: unless-stopped
+    depends_on:
+      - gitlab-amazonlinux
+    networks:
+      - gitlab-network-amazonlinux
+
+  gitlab-amazonlinux:
+    image: 'gitlab/gitlab-ce:latest'
+    container_name: gitlab-amazonlinux
+    restart: always
+    hostname: 'gitlab.local'
+    environment:
+      GITLAB_OMNIBUS_CONFIG: |
+        external_url 'http://gitlab.local'
+        gitlab_rails['gitlab_shell_ssh_port'] = 2222
+        # APIレート制限の設定
+        gitlab_rails['rate_limit_requests_per_period'] = 300
+        gitlab_rails['rate_limit_period'] = 3600  # 1時間
+        # Amazon Linux環境用の最適化
+        gitlab_rails['max_request_duration_seconds'] = 60
+    ports:
+      - '80:80'  # Amazon Linux版は標準ポートを使用
+      - '443:443'
+      - '2222:22'
+    volumes:
+      - 'gitlab-config-amazonlinux:/etc/gitlab:z'
+      - 'gitlab-logs-amazonlinux:/var/log/gitlab:z'
+      - 'gitlab-data-amazonlinux:/var/opt/gitlab:z'
+    shm_size: '256m'
+    networks:
+      - gitlab-network-amazonlinux
+
+volumes:
+  gitlab-config-amazonlinux:
+  gitlab-logs-amazonlinux:
+  gitlab-data-amazonlinux:
+
+networks:
+  gitlab-network-amazonlinux:
+    driver: bridge

--- a/container/claudecode/forpasipde/docker-compose-debian.yml
+++ b/container/claudecode/forpasipde/docker-compose-debian.yml
@@ -1,0 +1,64 @@
+version: '3.8'
+
+services:
+  claudecode-debian:
+    build:
+      context: .
+      dockerfile: debian.Dockerfile
+    container_name: claude-code-debian
+    volumes:
+      - ./.env:/.env:ro  # 環境変数ファイルをマウント（読み取り専用）
+      - ./workdir:/app/workdir:z  # 作業ディレクトリをマウント（SELinuxラベル共有モード）
+      - ./add_gitlab_mcp.json:/app/add_gitlab_mcp.json:z  # GitLab MCP設定ファイル
+      - ./add_mcp.json:/app/add_mcp.json:z  # MCP設定ファイル
+    environment:
+      - CLAUDE_CODE_USE_BEDROCK=${CLAUDE_CODE_USE_BEDROCK:-1}
+      - ANTHROPIC_MODEL=${ANTHROPIC_MODEL:-us.anthropic.claude-sonnet-4-20250514-v1:0}
+      - ANTHROPIC_SMALL_FAST_MODEL=${ANTHROPIC_SMALL_FAST_MODEL:-us.anthropic.claude-3-5-haiku-20241022-v1:0}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_REGION=${AWS_REGION:-us-east-1}
+      - GITLAB_API_TOKEN=${GITLAB_API_TOKEN}
+      - GITLAB_PERSONAL_ACCESS_TOKEN=${GITLAB_API_TOKEN}
+    tty: true
+    stdin_open: true
+    restart: unless-stopped
+    depends_on:
+      - gitlab-debian
+    networks:
+      - gitlab-network-debian
+
+  gitlab-debian:
+    image: 'gitlab/gitlab-ce:latest'
+    container_name: gitlab-debian
+    restart: always
+    hostname: 'gitlab.local'
+    environment:
+      GITLAB_OMNIBUS_CONFIG: |
+        external_url 'http://gitlab.local'
+        gitlab_rails['gitlab_shell_ssh_port'] = 2222
+        # APIレート制限の設定
+        gitlab_rails['rate_limit_requests_per_period'] = 300
+        gitlab_rails['rate_limit_period'] = 3600  # 1時間
+        # Debian環境用の最適化
+        gitlab_rails['max_request_duration_seconds'] = 55
+    ports:
+      - '8081:80'  # Debian版は8081ポートを使用
+      - '8444:443'
+      - '2224:22'  # SSH用ポートも変更
+    volumes:
+      - 'gitlab-config-debian:/etc/gitlab:z'
+      - 'gitlab-logs-debian:/var/log/gitlab:z'
+      - 'gitlab-data-debian:/var/opt/gitlab:z'
+    shm_size: '256m'
+    networks:
+      - gitlab-network-debian
+
+volumes:
+  gitlab-config-debian:
+  gitlab-logs-debian:
+  gitlab-data-debian:
+
+networks:
+  gitlab-network-debian:
+    driver: bridge

--- a/container/claudecode/forpasipde/docker-compose-node.yml
+++ b/container/claudecode/forpasipde/docker-compose-node.yml
@@ -1,0 +1,64 @@
+version: '3.8'
+
+services:
+  claudecode-node:
+    build:
+      context: .
+      dockerfile: node-slim.Dockerfile
+    container_name: claude-code-node
+    volumes:
+      - ./.env:/.env:ro  # 環境変数ファイルをマウント（読み取り専用）
+      - ./workdir:/app/workdir:z  # 作業ディレクトリをマウント（SELinuxラベル共有モード）
+      - ./add_gitlab_mcp.json:/app/add_gitlab_mcp.json:z  # GitLab MCP設定ファイル
+      - ./add_mcp.json:/app/add_mcp.json:z  # MCP設定ファイル
+    environment:
+      - CLAUDE_CODE_USE_BEDROCK=${CLAUDE_CODE_USE_BEDROCK:-1}
+      - ANTHROPIC_MODEL=${ANTHROPIC_MODEL:-us.anthropic.claude-sonnet-4-20250514-v1:0}
+      - ANTHROPIC_SMALL_FAST_MODEL=${ANTHROPIC_SMALL_FAST_MODEL:-us.anthropic.claude-3-5-haiku-20241022-v1:0}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_REGION=${AWS_REGION:-us-east-1}
+      - GITLAB_API_TOKEN=${GITLAB_API_TOKEN}
+      - GITLAB_PERSONAL_ACCESS_TOKEN=${GITLAB_API_TOKEN}
+    tty: true
+    stdin_open: true
+    restart: unless-stopped
+    depends_on:
+      - gitlab
+    networks:
+      - gitlab-network
+
+  gitlab:
+    image: 'gitlab/gitlab-ce:latest'
+    container_name: gitlab-node
+    restart: always
+    hostname: 'gitlab.local'
+    environment:
+      GITLAB_OMNIBUS_CONFIG: |
+        external_url 'http://gitlab.local'
+        gitlab_rails['gitlab_shell_ssh_port'] = 2222
+        # APIレート制限の設定
+        gitlab_rails['rate_limit_requests_per_period'] = 300
+        gitlab_rails['rate_limit_period'] = 3600  # 1時間
+        # Node.js環境用の最適化（ワーカータイムアウト60秒未満に設定）
+        gitlab_rails['max_request_duration_seconds'] = 50
+    ports:
+      - '8080:80'  # Node.js版は8080ポートを使用
+      - '8443:443'
+      - '2223:22'  # SSH用ポートも変更
+    volumes:
+      - 'gitlab-config-node:/etc/gitlab:z'
+      - 'gitlab-logs-node:/var/log/gitlab:z'
+      - 'gitlab-data-node:/var/opt/gitlab:z'
+    shm_size: '256m'
+    networks:
+      - gitlab-network
+
+volumes:
+  gitlab-config-node:
+  gitlab-logs-node:
+  gitlab-data-node:
+
+networks:
+  gitlab-network:
+    driver: bridge

--- a/container/claudecode/forpasipde/docker-compose-node.yml
+++ b/container/claudecode/forpasipde/docker-compose-node.yml
@@ -35,7 +35,7 @@ services:
     hostname: 'gitlab.local'
     environment:
       GITLAB_OMNIBUS_CONFIG: |
-        external_url 'http://gitlab.local'
+        external_url 'http://mcp.shift-terminus.com'
         gitlab_rails['gitlab_shell_ssh_port'] = 2222
         # APIレート制限の設定
         gitlab_rails['rate_limit_requests_per_period'] = 300

--- a/container/claudecode/forpasipde/docker-compose.yml
+++ b/container/claudecode/forpasipde/docker-compose.yml
@@ -1,0 +1,53 @@
+version: '3.8'
+
+services:
+  claudecode:
+    build:
+      context: .
+      dockerfile: amazonlinux.Dockerfile
+    volumes:
+      - ./.env:/.env:ro  # 環境変数ファイルをマウント（読み取り専用）
+      - ./workdir:/app/workdir:z  # 作業ディレクトリをマウント（SELinuxラベル共有モード）
+      - ./setup.sh:/app/setup.sh:z  # setup.shをマウント
+    environment:
+      - CLAUDE_CODE_USE_BEDROCK=${CLAUDE_CODE_USE_BEDROCK:-1}
+      - ANTHROPIC_MODEL=${ANTHROPIC_MODEL:-us.anthropic.claude-3-7-sonnet-20250219-v1:0}
+      - ANTHROPIC_SMALL_FAST_MODEL=${ANTHROPIC_SMALL_FAST_MODEL:-us.anthropic.claude-3-5-haiku-20241022-v1:0}
+    tty: true
+    stdin_open: true
+    restart: unless-stopped
+    depends_on:
+      - gitlab
+
+  gitlab:
+    image: 'gitlab/gitlab-ce:latest'
+    container_name: gitlab
+    restart: always
+    hostname: 'gitlab.local'
+    environment:
+      GITLAB_OMNIBUS_CONFIG: |
+        external_url 'http://gitlab.local'
+        gitlab_rails['gitlab_shell_ssh_port'] = 2222
+        # APIレート制限の設定
+        gitlab_rails['rate_limit_requests_per_period'] = 300
+        gitlab_rails['rate_limit_period'] = 3600  # 1時間
+    ports:
+      - '80:80'
+      - '443:443'
+      - '2222:22'
+    volumes:
+      - 'gitlab-config:/etc/gitlab:z'
+      - 'gitlab-logs:/var/log/gitlab:z'
+      - 'gitlab-data:/var/opt/gitlab:z'
+    shm_size: '256m'
+    networks:
+      - gitlab-network
+
+volumes:
+  gitlab-config:
+  gitlab-logs:
+  gitlab-data:
+
+networks:
+  gitlab-network:
+    driver: bridge

--- a/container/claudecode/forpasipde/github_to_gitlab_mcp_migration.md
+++ b/container/claudecode/forpasipde/github_to_gitlab_mcp_migration.md
@@ -1,0 +1,108 @@
+# GitHub MCPからGitLab MCPへの移行ガイド
+
+このドキュメントでは、GitHub MCPからGitLab MCPへの移行手順を説明します。
+
+## 前提条件
+
+- Node.jsとnpmがインストールされていること
+- Claude Codeがインストールされていること
+- GitLabアカウントとAPIアクセストークンが準備されていること
+
+## GitLabアクセストークンの取得
+
+1. GitLabにログインします
+2. 右上のプロフィールアイコンをクリックし、「設定」を選択
+3. 左側のメニューから「アクセストークン」を選択
+4. 以下の設定でトークンを作成します:
+   - 名前: `Claude Code MCP` (任意)
+   - 有効期限: 必要に応じて設定
+   - スコープ: `api`, `read_repository`, `write_repository` を選択
+5. 「アクセストークンを作成」をクリック
+6. 表示されたトークンをコピーして保存（このトークンは再表示されないので注意）
+
+## 環境変数の設定
+
+以下のコマンドで環境変数を設定します：
+
+```bash
+export GITLAB_API_TOKEN="your-gitlab-token"
+```
+
+永続的に設定する場合は、.bashrcや.zshrcに追加します：
+
+```bash
+echo 'export GITLAB_API_TOKEN="your-gitlab-token"' >> ~/.bashrc
+# または
+echo 'export GITLAB_API_TOKEN="your-gitlab-token"' >> ~/.zshrc
+```
+
+## GitLab MCPのインストールと設定
+
+### 1. パッケージのインストール
+
+```bash
+npm install -g @modelcontextprotocol/server-gitlab
+```
+
+### 2. MCPの設定ファイルの作成
+
+以下の内容の`add_gitlab_mcp.json`ファイルを作成します：
+
+```json
+{
+  "command": "npx",
+  "args": ["-y", "@modelcontextprotocol/server-gitlab"],
+  "env": {
+    "GITLAB_PERSONAL_ACCESS_TOKEN": "${GITLAB_API_TOKEN}"
+  }
+}
+```
+
+### 3. Claude CodeへのMCP追加
+
+```bash
+envsubst < add_gitlab_mcp.json > add_token_gitlab_mcp.json
+claude mcp add-json gitlab-org "$(cat add_token_gitlab_mcp.json)" --verbose
+rm -f add_token_gitlab_mcp.json
+```
+
+### 4. 設定の確認
+
+```bash
+claude mcp list
+```
+
+出力に`gitlab-org`が表示されていることを確認します。
+
+## GitHub MCPの削除（オプション）
+
+もしGitHub MCPが不要になった場合は、以下のコマンドで削除できます：
+
+```bash
+claude mcp remove github-org
+```
+
+## GitLab MCPの使用
+
+Claude Codeを起動する際、GitLab関連のタスクを実行することで、GitLab MCPが自動的に使用されます。
+
+## GitHub MCPとGitLab MCPの主な違い
+
+| 項目 | GitHub MCP | GitLab MCP |
+|------|------------|------------|
+| 環境変数 | GITHUB_PERSONAL_ACCESS_TOKEN | GITLAB_PERSONAL_ACCESS_TOKEN |
+| APIエンドポイント | api.github.com | gitlab.comのAPI |
+| 機能 | リポジトリ操作、Issue、PR管理など | リポジトリ操作、Issue、MR管理など |
+| プルリクエスト名 | Pull Request (PR) | Merge Request (MR) |
+
+## トラブルシューティング
+
+- **認証エラー**: 環境変数`GITLAB_PERSONAL_ACCESS_TOKEN`が正しく設定されているか確認してください
+- **アクセス権限エラー**: GitLabトークンに適切なスコープが設定されているか確認してください
+- **MCP登録エラー**: `claude mcp list`を実行して、現在の登録状況を確認してください
+
+## 参考リソース
+
+- [Model Context Protocol](https://modelcontextprotocol.io/)
+- [GitLab API Documentation](https://docs.gitlab.com/ee/api/)
+- [@modelcontextprotocol/server-gitlab](https://www.npmjs.com/package/@modelcontextprotocol/server-gitlab)

--- a/container/claudecode/forpasipde/gitlab_mcp_implementation_plan.md
+++ b/container/claudecode/forpasipde/gitlab_mcp_implementation_plan.md
@@ -1,0 +1,120 @@
+# GitLab MCP実装計画
+
+## 調査結果サマリー
+
+GitLab MCPの設定と実装に関する調査を行いました。GitHub MCPからGitLab MCPへの移行に必要な情報は以下の通りです。
+
+### 主な調査結果
+
+1. **利用可能なパッケージ**:
+   - 公式: `@modelcontextprotocol/server-gitlab` (バージョン: 2025.4.25)
+   - サードパーティ: `@zereight/mcp-gitlab`、`@therealchristhomas/gitlab-mcp-server`
+
+2. **必要な認証情報**:
+   - 環境変数 `GITLAB_PERSONAL_ACCESS_TOKEN` にGitLabのアクセストークンを設定する必要がある
+
+3. **設定方法**:
+   - Claude CodeのMCP設定は、`claude mcp add-json`コマンドでJSON設定ファイルを使って行う
+
+4. **GitHub MCPとの主な違い**:
+   - 認証用の環境変数名が異なる（`GITHUB_PERSONAL_ACCESS_TOKEN` → `GITLAB_PERSONAL_ACCESS_TOKEN`）
+   - APIエンドポイントの構造とパラメータが異なる
+   - PRの代わりにMerge Request(MR)を使用
+
+## 実装計画
+
+### フェーズ1: 環境セットアップ (推定所要時間: 1日)
+
+1. **GitLabアカウント設定**:
+   - GitLabアカウントの作成（既に存在する場合はスキップ）
+   - APIアクセストークンの生成（スコープ: api, read_repository, write_repository）
+
+2. **ローカル環境設定**:
+   - 環境変数 `GITLAB_API_TOKEN` の設定
+   - `@modelcontextprotocol/server-gitlab` のインストール
+   - MCP設定ファイルの作成と適用
+
+### フェーズ2: 基本機能テスト (推定所要時間: 2-3日)
+
+1. **リポジトリ操作のテスト**:
+   - リポジトリ作成
+   - ファイル読み込み
+   - コードの検索
+   - ファイル作成・更新
+
+2. **Issue管理のテスト**:
+   - Issue作成
+   - Issue更新
+   - コメント追加
+
+3. **Merge Request操作のテスト**:
+   - ブランチ作成
+   - MR作成
+   - レビュー追加
+   - マージ操作
+
+### フェーズ3: 本番環境への移行 (推定所要時間: 1-2日)
+
+1. **設定ファイルの更新**:
+   - `setup.sh` の更新
+   - 必要に応じて `setup_gitlab_mcp.sh` を統合
+
+2. **デプロイとテスト**:
+   - 本番環境でのインストールと設定
+   - 基本機能の動作確認
+
+3. **ドキュメント更新**:
+   - 移行ガイドの最終化
+   - トラブルシューティングセクションの充実
+
+### フェーズ4: モニタリングと最適化 (推定所要時間: 継続的)
+
+1. **パフォーマンスモニタリング**:
+   - API呼び出しの速度と効率性の確認
+   - エラー発生率の監視
+
+2. **フィードバックと改善**:
+   - ユーザーフィードバックの収集
+   - 必要に応じた設定の最適化
+
+## 必要なリソース
+
+1. **アクセス権限**:
+   - GitLabアカウント
+   - GitLab APIトークン（適切なスコープ付き）
+   - リポジトリへのアクセス権限
+
+2. **ソフトウェア環境**:
+   - Node.js と npm
+   - Claude Code
+   - Git
+
+3. **ドキュメント**:
+   - GitLab API リファレンス
+   - MCP設定リファレンス
+
+## リスク評価
+
+1. **技術的リスク**:
+   - GitLab MCPの機能がGitHub MCPと完全に同等でない可能性
+   - APIの仕様変更によるトラブル
+
+2. **セキュリティリスク**:
+   - トークンの適切な管理（環境変数、シェル履歴）
+   - 権限設定の適切な範囲設定
+
+3. **運用リスク**:
+   - チームメンバーの習熟度の差
+   - 移行中のダウンタイム
+
+## 次のステップ
+
+1. GitLabアカウントの設定と権限確認
+2. テスト環境での`setup_gitlab_mcp.sh`の実行と検証
+3. 基本機能テストの実施とフィードバック収集
+
+## 参考資料
+
+- NPMパッケージ: [@modelcontextprotocol/server-gitlab](https://www.npmjs.com/package/@modelcontextprotocol/server-gitlab)
+- GitLab API: [GitLab API Documentation](https://docs.gitlab.com/ee/api/)
+- Model Context Protocol: [MCP公式サイト](https://modelcontextprotocol.io/)

--- a/container/claudecode/forpasipde/node-alpine.Dockerfile
+++ b/container/claudecode/forpasipde/node-alpine.Dockerfile
@@ -1,0 +1,57 @@
+FROM node:18-alpine
+
+# 必要なパッケージのインストール
+RUN apk add --no-cache \
+    git \
+    curl \
+    bash \
+    ca-certificates \
+    wget \
+    tar \
+    zip \
+    unzip \
+    shadow
+
+# nvmのインストール (Alpineでは特別な設定が必要)
+ENV NVM_DIR /usr/local/nvm
+RUN mkdir -p $NVM_DIR
+RUN apk add --no-cache --virtual .build-deps \
+    build-base \
+    python3 \
+    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash \
+    && apk del .build-deps
+
+# nvmセットアップのためのシェル設定
+RUN echo 'export NVM_DIR="/usr/local/nvm"' >> /etc/profile.d/nvm.sh \
+    && echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> /etc/profile.d/nvm.sh
+
+# GitLab CLIのインストール (Alpine用にバイナリをダウンロード)
+RUN wget -O /usr/local/bin/gitlab-cli https://gitlab.com/gitlab-org/cli/releases/download/v1.30.0/gitlab-cli-linux-amd64 \
+    && chmod +x /usr/local/bin/gitlab-cli
+
+# 専用ユーザーの作成
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+# 作業ディレクトリの設定
+WORKDIR /app
+
+# アプリケーションのファイルをコピー
+COPY package*.json ./
+
+# 依存関係のインストール
+RUN npm install
+
+# 残りのアプリケーションコードをコピー
+COPY . .
+
+# アプリケーションディレクトリの所有者を変更
+RUN chown -R appuser:appgroup /app
+
+# アプリケーションユーザーに切り替え
+USER appuser
+
+# アプリケーションのポート公開
+EXPOSE 3000
+
+# 起動コマンド
+CMD ["npm", "start"]

--- a/container/claudecode/forpasipde/node-slim.Dockerfile
+++ b/container/claudecode/forpasipde/node-slim.Dockerfile
@@ -1,0 +1,45 @@
+FROM node:18-slim
+
+# GitLab連携やnvm、その他必要なツールのインストール
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    ca-certificates \
+    gnupg \
+    wget \
+    zip \
+    unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+# nvmのインストール
+ENV NVM_DIR /usr/local/nvm
+RUN mkdir -p $NVM_DIR
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash
+
+# nvmセットアップのためのシェル設定
+RUN echo 'export NVM_DIR="/usr/local/nvm"' >> /etc/profile.d/nvm.sh \
+    && echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> /etc/profile.d/nvm.sh
+
+# GitLab CLIのインストール（オプション）
+RUN curl -s https://packages.gitlab.com/install/repositories/gitlab/gitlab-ee/script.deb.sh | bash \
+    && apt-get update \
+    && apt-get install -y gitlab-cli \
+    && rm -rf /var/lib/apt/lists/*
+
+# 作業ディレクトリの設定
+WORKDIR /app
+
+# アプリケーションのファイルをコピー
+COPY package*.json ./
+
+# 依存関係のインストール
+RUN npm install
+
+# 残りのアプリケーションコードをコピー
+COPY . .
+
+# アプリケーションのポート公開
+EXPOSE 3000
+
+# 起動コマンド
+CMD ["npm", "start"]

--- a/container/claudecode/forpasipde/run-podman.sh
+++ b/container/claudecode/forpasipde/run-podman.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+
+# Claude Code実行環境起動スクリプト（podman-compose対応版）
+
+# 使用方法を表示する関数
+show_usage() {
+    echo "使用方法: $0 [BASE_IMAGE]"
+    echo ""
+    echo "BASE_IMAGE オプション:"
+    echo "  node        Node.js slim版を起動（デフォルト）"
+    echo "  debian      Debian slim版を起動"
+    echo "  amazonlinux Amazon Linux版を起動"
+    echo ""
+    echo "例:"
+    echo "  $0           # Node.js slim版を起動"
+    echo "  $0 node      # Node.js slim版を起動"
+    echo "  $0 debian    # Debian slim版を起動"
+    echo "  $0 amazonlinux # Amazon Linux版を起動"
+    echo ""
+}
+
+# .envファイルが存在するか確認
+if [ ! -f .env ]; then
+    echo "エラー: .envファイルが見つかりません。"
+    echo ".env.exampleをコピーして必要な値を設定してください。"
+    echo "cp .env.example .env"
+    exit 1
+fi
+
+# workdirディレクトリの確認と作成
+if [ ! -d ./workdir ]; then
+    echo "workdirディレクトリが存在しません。作成します..."
+    mkdir -p ./workdir
+    echo "✅ workdirディレクトリを作成しました。"
+fi
+
+# 引数の処理
+BASE_IMAGE=${1:-node}  # デフォルトはNode.js slim版
+
+# 対応するdocker-composeファイルの選択
+case $BASE_IMAGE in
+    node)
+        COMPOSE_FILE="docker-compose-node.yml"
+        echo "🚀 Node.js slim版 Claude Code環境を起動します..."
+        ;;
+    debian)
+        COMPOSE_FILE="docker-compose-debian.yml"
+        echo "⚡ Debian slim版 Claude Code環境を起動します..."
+        ;;
+    amazonlinux)
+        COMPOSE_FILE="docker-compose-amazonlinux.yml"
+        echo "📝 Amazon Linux版 Claude Code環境を起動します..."
+        ;;
+    --help|-h|help)
+        show_usage
+        exit 0
+        ;;
+    *)
+        echo "エラー: 無効なベースイメージ '$BASE_IMAGE' が指定されました。"
+        echo ""
+        show_usage
+        exit 1
+        ;;
+esac
+
+# docker-composeファイルの存在確認
+if [ ! -f "$COMPOSE_FILE" ]; then
+    echo "エラー: $COMPOSE_FILE が見つかりません。"
+    echo "選択されたベースイメージ ($BASE_IMAGE) はまだ実装されていない可能性があります。"
+    echo ""
+    echo "利用可能なファイル:"
+    ls -la docker-compose*.yml 2>/dev/null || echo "  docker-composeファイルが見つかりません"
+    exit 1
+fi
+
+# 実行前の確認
+echo "設定内容:"
+echo "  ベースイメージ: $BASE_IMAGE"
+echo "  Composeファイル: $COMPOSE_FILE"
+echo "  環境設定ファイル: .env"
+echo ""
+
+# podmanとpodman-composeの確認
+if ! command -v podman &> /dev/null; then
+    echo "エラー: podmanがインストールされていません。"
+    exit 1
+fi
+
+if ! command -v podman-compose &> /dev/null; then
+    echo "エラー: podman-composeがインストールされていません。"
+    exit 1
+fi
+
+# GitLabコンテナの手動起動
+echo "GitLabコンテナを起動中..."
+podman run -d --name gitlab-node \
+    -p 8080:80 -p 8443:443 -p 2223:22 \
+    -v gitlab-config-node:/etc/gitlab:z \
+    -v gitlab-logs-node:/var/log/gitlab:z \
+    -v gitlab-data-node:/var/opt/gitlab:z \
+    --shm-size=256m \
+    --hostname gitlab.local \
+    gitlab/gitlab-ce:latest
+
+sleep 10
+
+# Claude Codeコンテナの起動
+echo "Claude Codeコンテナを起動中..."
+podman build -t claudecode-node -f node-slim.Dockerfile .
+
+podman run -d --name claude-code-node \
+    -v ./.env:/.env:ro \
+    -v ./workdir:/app/workdir:z \
+    -v ./add_gitlab_mcp.json:/app/add_gitlab_mcp.json:z \
+    -v ./add_mcp.json:/app/add_mcp.json:z \
+    --env-file .env \
+    --tty \
+    claudecode-node
+
+# 起動確認
+if [ $? -eq 0 ]; then
+    echo ""
+    echo "✅ Claude Code環境が正常に起動しました！"
+    echo ""
+    echo "次のステップ:"
+    echo "1. コンテナに接続: podman exec -it claude-code-node bash"
+    echo "2. ログ確認: podman logs -f claude-code-node"
+    echo "3. 停止: podman stop claude-code-node gitlab-node"
+    echo ""
+    echo "GitLab管理画面:"
+    echo "  http://localhost:8080 (Node.js版用)"
+    echo ""
+else
+    echo "❌ コンテナの起動に失敗しました。"
+    echo "ログを確認してください: podman logs claude-code-node"
+    exit 1
+fi

--- a/container/claudecode/forpasipde/run.sh
+++ b/container/claudecode/forpasipde/run.sh
@@ -1,11 +1,122 @@
 #!/bin/bash
 
+# Claude Code実行環境起動スクリプト（複数ベースイメージ対応）
+
+# 使用方法を表示する関数
+show_usage() {
+    echo "使用方法: $0 [BASE_IMAGE]"
+    echo ""
+    echo "BASE_IMAGE オプション:"
+    echo "  node        Node.js slim版を起動（デフォルト）"
+    echo "  debian      Debian slim版を起動"
+    echo "  amazonlinux Amazon Linux版を起動"
+    echo ""
+    echo "例:"
+    echo "  $0           # Node.js slim版を起動"
+    echo "  $0 node      # Node.js slim版を起動"
+    echo "  $0 debian    # Debian slim版を起動"
+    echo "  $0 amazonlinux # Amazon Linux版を起動"
+    echo ""
+}
+
 # .envファイルが存在するか確認
 if [ ! -f .env ]; then
-  echo "エラー: .envファイルが見つかりません。.env.exampleをコピーして必要な値を設定してください。"
-  echo "cp .env.example .env"
-  exit 1
+    echo "エラー: .envファイルが見つかりません。"
+    echo ".env.exampleをコピーして必要な値を設定してください。"
+    echo "cp .env.example .env"
+    exit 1
 fi
 
-# コンテナ起動
-docker-compose up -d
+# 引数の処理
+BASE_IMAGE=${1:-node}  # デフォルトはNode.js slim版
+
+# 対応するdocker-composeファイルの選択
+case $BASE_IMAGE in
+    node)
+        COMPOSE_FILE="docker-compose-node.yml"
+        echo "🚀 Node.js slim版 Claude Code環境を起動します..."
+        ;;
+    debian)
+        COMPOSE_FILE="docker-compose-debian.yml"
+        echo "⚡ Debian slim版 Claude Code環境を起動します..."
+        ;;
+    amazonlinux)
+        COMPOSE_FILE="docker-compose-amazonlinux.yml"
+        echo "📝 Amazon Linux版 Claude Code環境を起動します..."
+        ;;
+    --help|-h|help)
+        show_usage
+        exit 0
+        ;;
+    *)
+        echo "エラー: 無効なベースイメージ '$BASE_IMAGE' が指定されました。"
+        echo ""
+        show_usage
+        exit 1
+        ;;
+esac
+
+# docker-composeファイルの存在確認
+if [ ! -f "$COMPOSE_FILE" ]; then
+    echo "エラー: $COMPOSE_FILE が見つかりません。"
+    echo "選択されたベースイメージ ($BASE_IMAGE) はまだ実装されていない可能性があります。"
+    echo ""
+    echo "利用可能なファイル:"
+    ls -la docker-compose*.yml 2>/dev/null || echo "  docker-composeファイルが見つかりません"
+    exit 1
+fi
+
+# 実行前の確認
+echo "設定内容:"
+echo "  ベースイメージ: $BASE_IMAGE"
+echo "  Composeファイル: $COMPOSE_FILE"
+echo "  環境設定ファイル: .env"
+echo ""
+
+# DockerとDocker Composeの確認
+if ! command -v docker &> /dev/null; then
+    echo "エラー: Dockerがインストールされていません。"
+    exit 1
+fi
+
+if ! command -v docker-compose &> /dev/null; then
+    echo "エラー: Docker Composeがインストールされていません。"
+    exit 1
+fi
+
+# 既存のコンテナを停止（クリーンアップ）
+echo "既存のコンテナを停止しています..."
+docker-compose -f "$COMPOSE_FILE" down 2>/dev/null || true
+
+# コンテナの起動
+echo "コンテナを起動しています..."
+docker-compose -f "$COMPOSE_FILE" up -d
+
+# 起動確認
+if [ $? -eq 0 ]; then
+    echo ""
+    echo "✅ Claude Code環境が正常に起動しました！"
+    echo ""
+    echo "次のステップ:"
+    echo "1. コンテナに接続: docker-compose -f $COMPOSE_FILE exec claudecode-$BASE_IMAGE bash"
+    echo "2. ログ確認: docker-compose -f $COMPOSE_FILE logs -f"
+    echo "3. 停止: docker-compose -f $COMPOSE_FILE down"
+    echo ""
+    echo "GitLab管理画面:"
+    case $BASE_IMAGE in
+        node)
+            echo "  http://localhost:8080 (Node.js版用)"
+            ;;
+        debian)
+            echo "  http://localhost:8081 (Debian版用)"
+            ;;
+        amazonlinux|*)
+            echo "  http://localhost:80 (Amazon Linux版用)"
+            ;;
+    esac
+    echo ""
+else
+    echo "❌ コンテナの起動に失敗しました。"
+    echo "ログを確認してください: docker-compose -f $COMPOSE_FILE logs"
+    exit 1
+fi

--- a/container/claudecode/forpasipde/run.sh
+++ b/container/claudecode/forpasipde/run.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# .envファイルが存在するか確認
+if [ ! -f .env ]; then
+  echo "エラー: .envファイルが見つかりません。.env.exampleをコピーして必要な値を設定してください。"
+  echo "cp .env.example .env"
+  exit 1
+fi
+
+# コンテナ起動
+docker-compose up -d

--- a/container/claudecode/forpasipde/run.sh
+++ b/container/claudecode/forpasipde/run.sh
@@ -27,6 +27,13 @@ if [ ! -f .env ]; then
     exit 1
 fi
 
+# workdirディレクトリの確認と作成
+if [ ! -d ./workdir ]; then
+    echo "workdirディレクトリが存在しません。作成します..."
+    mkdir -p ./workdir
+    echo "✅ workdirディレクトリを作成しました。"
+fi
+
 # 引数の処理
 BASE_IMAGE=${1:-node}  # デフォルトはNode.js slim版
 

--- a/container/claudecode/forpasipde/setup-amazonlinux.sh
+++ b/container/claudecode/forpasipde/setup-amazonlinux.sh
@@ -1,11 +1,31 @@
 #!/bin/bash
 
-# Node.js版Claude Code環境セットアップスクリプト
-echo "=== Node.js slim版 Claude Code セットアップ開始 ==="
+# Amazon Linux版Claude Code環境セットアップスクリプト
+echo "=== Amazon Linux版 Claude Code セットアップ開始 ==="
 
-# Node.jsとnpmのバージョン確認
-echo "Node.js version: $(node --version)"
-echo "npm version: $(npm --version)"
+# nvmとNode.jsのインストール確認
+if command -v node &> /dev/null; then
+    echo "Node.js version: $(node --version)"
+    echo "npm version: $(npm --version)"
+else
+    echo "Node.jsがインストールされていません。インストールを実行します..."
+    
+    # Amazon Linuxの場合はDNFを使用
+    echo "Node.js 22をインストールしています..."
+    dnf module install -y nodejs:22
+    
+    # npmの確認
+    echo "Node.js version: $(node --version)"
+    echo "npm version: $(npm --version)"
+    
+    # nvmのインストール（オプション）
+    echo "nvmをインストールしています..."
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash
+    
+    # nvmを現在のセッションで使用可能に
+    export NVM_DIR="$HOME/.nvm"
+    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+fi
 
 # Claude Codeの確認
 if command -v claude &> /dev/null; then
@@ -77,12 +97,12 @@ fi
 echo "=== MCP設定確認 ==="
 claude mcp list
 
-# bashrcに環境設定を追加（Node.js版専用）
+# bashrcに環境設定を追加（Amazon Linux版専用）
 echo "=== bashrc設定の追加 ==="
 cat <<EOF >> ~/.bashrc
-# Node.js Claude Code環境設定
-export PATH=\$PATH:/usr/local/bin
-export NODE_ENV=production
+# Amazon Linux Claude Code環境設定
+export NVM_DIR="\$HOME/.nvm"
+[ -s "\$NVM_DIR/nvm.sh" ] && \. "\$NVM_DIR/nvm.sh"
 
 # Claude Code設定
 export CLAUDE_CODE_USE_BEDROCK=\${CLAUDE_CODE_USE_BEDROCK:-1}
@@ -98,7 +118,7 @@ echo "✅ bashrc設定を追加しました"
 # 設定の反映
 source ~/.bashrc
 
-echo "=== Node.js slim版 Claude Code セットアップ完了 ==="
+echo "=== Amazon Linux版 Claude Code セットアップ完了 ==="
 echo ""
 echo "次のステップ:"
 echo "1. 'claude code' コマンドでClaude Codeを起動"

--- a/container/claudecode/forpasipde/setup-debian.sh
+++ b/container/claudecode/forpasipde/setup-debian.sh
@@ -1,11 +1,31 @@
 #!/bin/bash
 
-# Node.js版Claude Code環境セットアップスクリプト
-echo "=== Node.js slim版 Claude Code セットアップ開始 ==="
+# Debian版Claude Code環境セットアップスクリプト
+echo "=== Debian slim版 Claude Code セットアップ開始 ==="
 
-# Node.jsとnpmのバージョン確認
-echo "Node.js version: $(node --version)"
-echo "npm version: $(npm --version)"
+# nvmとNode.jsのインストール確認
+if command -v node &> /dev/null; then
+    echo "Node.js version: $(node --version)"
+    echo "npm version: $(npm --version)"
+else
+    echo "Node.jsがインストールされていません。インストールを実行します..."
+    
+    # nvmのインストール
+    echo "nvmをインストールしています..."
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash
+    
+    # nvmを現在のセッションで使用可能に
+    export NVM_DIR="$HOME/.nvm"
+    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+    
+    # Node.jsの安定版をインストール
+    echo "Node.js LTSをインストールしています..."
+    nvm install --lts
+    nvm use --lts
+    
+    echo "Node.js version: $(node --version)"
+    echo "npm version: $(npm --version)"
+fi
 
 # Claude Codeの確認
 if command -v claude &> /dev/null; then
@@ -77,12 +97,12 @@ fi
 echo "=== MCP設定確認 ==="
 claude mcp list
 
-# bashrcに環境設定を追加（Node.js版専用）
+# bashrcに環境設定を追加（Debian版専用）
 echo "=== bashrc設定の追加 ==="
 cat <<EOF >> ~/.bashrc
-# Node.js Claude Code環境設定
-export PATH=\$PATH:/usr/local/bin
-export NODE_ENV=production
+# Debian Claude Code環境設定
+export NVM_DIR="\$HOME/.nvm"
+[ -s "\$NVM_DIR/nvm.sh" ] && \. "\$NVM_DIR/nvm.sh"
 
 # Claude Code設定
 export CLAUDE_CODE_USE_BEDROCK=\${CLAUDE_CODE_USE_BEDROCK:-1}
@@ -98,7 +118,7 @@ echo "✅ bashrc設定を追加しました"
 # 設定の反映
 source ~/.bashrc
 
-echo "=== Node.js slim版 Claude Code セットアップ完了 ==="
+echo "=== Debian slim版 Claude Code セットアップ完了 ==="
 echo ""
 echo "次のステップ:"
 echo "1. 'claude code' コマンドでClaude Codeを起動"

--- a/container/claudecode/forpasipde/setup-node.sh
+++ b/container/claudecode/forpasipde/setup-node.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+# Node.js版Claude Code環境セットアップスクリプト
+echo "=== Node.js slim版 Claude Code セットアップ開始 ==="
+
+# Node.jsとnpmのバージョン確認
+echo "Node.js version: $(node --version)"
+echo "npm version: $(npm --version)"
+
+# Claude Codeの確認
+if command -v claude &> /dev/null; then
+    echo "Claude Code version: $(claude --version)"
+else
+    echo "Claude Codeがインストールされていません。インストールを実行します..."
+    npm install -g @anthropic-ai/claude-code
+fi
+
+# GitLab MCPサーバーの確認
+if npm list -g @modelcontextprotocol/server-gitlab &> /dev/null; then
+    echo "GitLab MCPサーバーは既にインストール済みです"
+else
+    echo "GitLab MCPサーバーをインストールします..."
+    npm install -g @modelcontextprotocol/server-gitlab
+fi
+
+# 環境変数の確認
+echo "=== 環境変数の確認 ==="
+if [ -z "$GITLAB_API_TOKEN" ]; then
+    echo "⚠️  GITLAB_API_TOKEN環境変数が設定されていません。"
+    echo "   GitLabからパーソナルアクセストークンを取得し、環境変数に設定してください。"
+else
+    echo "✅ GITLAB_API_TOKEN: 設定済み"
+fi
+
+if [ -z "$ANTHROPIC_MODEL" ]; then
+    echo "⚠️  ANTHROPIC_MODEL環境変数が設定されていません。"
+else
+    echo "✅ ANTHROPIC_MODEL: $ANTHROPIC_MODEL"
+fi
+
+if [ -z "$AWS_ACCESS_KEY_ID" ]; then
+    echo "⚠️  AWS認証情報が設定されていません。"
+else
+    echo "✅ AWS認証情報: 設定済み"
+fi
+
+# Claude Code設定ディレクトリの作成
+if [ ! -d ~/.claude" ]; then
+    mkdir -p ~/.claude
+    echo "Claude Code設定ディレクトリを作成しました: ~/.claude"
+fi
+
+# GitLab MCPの設定
+echo "=== GitLab MCP設定 ==="
+if [ -n "$GITLAB_API_TOKEN" ]; then
+    echo "GitLab MCPを設定します..."
+    
+    # 一時ファイルに環境変数を展開した設定を作成
+    if [ -f "/app/add_gitlab_mcp.json" ]; then
+        envsubst < /app/add_gitlab_mcp.json > /tmp/add_token_gitlab_mcp.json
+        
+        # GitLab MCPをClaude Codeに追加
+        claude mcp add-json gitlab-org "$(cat /tmp/add_token_gitlab_mcp.json)" --verbose
+        
+        # 一時ファイルを削除
+        rm -f /tmp/add_token_gitlab_mcp.json
+        
+        echo "✅ GitLab MCPの設定が完了しました"
+    else
+        echo "⚠️  GitLab MCP設定ファイルが見つかりません: /app/add_gitlab_mcp.json"
+    fi
+else
+    echo "⚠️  GITLAB_API_TOKENが設定されていないため、GitLab MCPの設定をスキップします"
+fi
+
+# MCP設定の確認
+echo "=== MCP設定確認 ==="
+claude mcp list
+
+# bashrcに環境設定を追加（Node.js版専用）
+echo "=== bashrc設定の追加 ==="
+cat <<EOF >> ~/.bashrc
+# Node.js Claude Code環境設定
+export PATH=\$PATH:/usr/local/bin
+export NODE_ENV=production
+
+# Claude Code設定
+export CLAUDE_CODE_USE_BEDROCK=\${CLAUDE_CODE_USE_BEDROCK:-1}
+export ANTHROPIC_MODEL=\${ANTHROPIC_MODEL:-us.anthropic.claude-sonnet-4-20250514-v1:0}
+export ANTHROPIC_SMALL_FAST_MODEL=\${ANTHROPIC_SMALL_FAST_MODEL:-us.anthropic.claude-3-5-haiku-20241022-v1:0}
+
+# GitLab連携設定
+export GITLAB_HOST=gitlab.local
+EOF
+
+echo "✅ bashrc設定を追加しました"
+
+# 設定の反映
+source ~/.bashrc
+
+echo "=== Node.js slim版 Claude Code セットアップ完了 ==="
+echo ""
+echo "次のステップ:"
+echo "1. 'claude code' コマンドでClaude Codeを起動"
+echo "2. GitLab連携が必要な場合は、http://gitlab.local でGitLabにアクセス"
+echo "3. 作業ディレクトリは /app/workdir を使用してください"
+echo ""

--- a/container/claudecode/forpasipde/setup.sh
+++ b/container/claudecode/forpasipde/setup.sh
@@ -1,0 +1,47 @@
+# Download and install nvm:
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+
+# in lieu of restarting the shell
+\. "$HOME/.nvm/nvm.sh"
+
+# Download and install Node.js:
+nvm install 22
+
+# Verify the Node.js version:
+node -v # Should print "v22.16.0".
+nvm current # Should print "v22.16.0".
+
+# Verify npm version:
+npm -v # Should print "10.9.2".
+
+npm install -g @anthropic-ai/claude-code
+npm install -g @modelcontextprotocol/server-github
+
+cat <<EOF >> /home/ec2-user/.bashrc
+# Claude codee 
+# Bedrockを使う設定
+export CLAUDE_CODE_USE_BEDROCK=1
+
+# Amazon Bedrock (モデルIDを使用)
+export ANTHROPIC_MODEL=us.anthropic.claude-3-7-sonnet-20250219-v1:0
+#export ANTHROPIC_MODEL=us.anthropic.claude-sonnet-4-20250514-v1:0
+export ANTHROPIC_SMALL_FAST_MODEL=us.anthropic.claude-3-5-haiku-20241022-v1:0
+. /home/ec2-user/.nvm/nvm.sh
+EOF
+
+cat <<EOF >> /home/ec2-user/.zshrc
+# Claude codee 
+# Bedrockを使う設定
+export CLAUDE_CODE_USE_BEDROCK=1
+
+# Amazon Bedrock (モデルIDを使用)
+export ANTHROPIC_MODEL=us.anthropic.claude-3-7-sonnet-20250219-v1:0
+#export ANTHROPIC_MODEL=us.anthropic.claude-sonnet-4-20250514-v1:0
+export ANTHROPIC_SMALL_FAST_MODEL=us.anthropic.claude-3-5-haiku-20241022-v1:0
+. /home/ec2-user/.nvm/nvm.sh
+EOF
+
+. ~/.bashrc
+envsubst < add_mcp.json > add_token_github_mcp.json
+claude mcp add-json github-org "$(cat add_token_github_mcp.json)" --verbose
+rm -f add_token_github_mcp.json

--- a/container/claudecode/forpasipde/setup_gitlab_mcp.sh
+++ b/container/claudecode/forpasipde/setup_gitlab_mcp.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# GitLab MCPをインストール
+npm install -g @modelcontextprotocol/server-gitlab
+
+# 環境変数の設定
+if [ -z "$GITLAB_API_TOKEN" ]; then
+    echo "GITLAB_API_TOKEN環境変数が設定されていません。"
+    echo "GitLabからパーソナルアクセストークンを取得し、環境変数に設定してください。"
+    exit 1
+fi
+
+# 一時ファイルに環境変数を展開した設定を作成
+envsubst < add_gitlab_mcp.json > add_token_gitlab_mcp.json
+
+# GitLab MCPをClaude Codeに追加
+claude mcp add-json gitlab-org "$(cat add_token_gitlab_mcp.json)" --verbose
+
+# 一時ファイルを削除
+rm -f add_token_gitlab_mcp.json
+
+echo "GitLab MCPの設定が完了しました。"

--- a/container/claudecode/forpasipde/ubuntu.Dockerfile
+++ b/container/claudecode/forpasipde/ubuntu.Dockerfile
@@ -1,0 +1,64 @@
+FROM ubuntu:22.04
+
+# 対話型のプロンプトを表示させない
+ENV DEBIAN_FRONTEND=noninteractive
+
+# タイムゾーンを設定
+ENV TZ=UTC
+
+# 必要なパッケージのインストール
+RUN apt-get update && apt-get install -y \
+    nodejs \
+    npm \
+    git \
+    curl \
+    wget \
+    zip \
+    unzip \
+    tzdata \
+    ca-certificates \
+    gnupg \
+    lsb-release \
+    && rm -rf /var/lib/apt/lists/*
+
+# nvmのインストール
+ENV NVM_DIR /usr/local/nvm
+RUN mkdir -p $NVM_DIR
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash
+
+# nvmセットアップのためのシェル設定
+RUN echo 'export NVM_DIR="/usr/local/nvm"' >> /etc/profile.d/nvm.sh \
+    && echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> /etc/profile.d/nvm.sh
+
+# GitLab CLIのインストール（オプション）
+RUN curl -s https://packages.gitlab.com/install/repositories/gitlab/gitlab-ee/script.deb.sh | bash \
+    && apt-get update \
+    && apt-get install -y gitlab-cli \
+    && rm -rf /var/lib/apt/lists/*
+
+# 専用ユーザーの作成
+RUN useradd -ms /bin/bash appuser
+
+# 作業ディレクトリの設定
+WORKDIR /app
+
+# アプリケーションのファイルをコピー
+COPY package*.json ./
+
+# 依存関係のインストール
+RUN npm install
+
+# 残りのアプリケーションコードをコピー
+COPY . .
+
+# アプリケーションディレクトリの所有者を変更
+RUN chown -R appuser:appuser /app
+
+# アプリケーションユーザーに切り替え
+USER appuser
+
+# アプリケーションのポート公開
+EXPOSE 3000
+
+# 起動コマンド
+CMD ["npm", "start"]


### PR DESCRIPTION
## 概要
このPRでは、以下の改善を行いました：

1. Podman環境で実行するための専用スクリプト `run-podman.sh` を追加
   - 従来のDocker Compose対応に加え、Podmanにも対応可能に
   - SELinux環境でのボリュームマウントをサポート（:zラベル共有モード）

2. docker-compose-node.yml設定を更新
   - GitLabのexternal_urlを更新してより適切なドメイン名を設定

## 動作確認方法
1. 以下のコマンドでPodman対応コンテナを起動：
```bash
./run-podman.sh
```

2. 起動後、以下のコマンドでコンテナに接続：
```bash
podman exec -it claude-code-node bash
```

🤖 Generated with [Claude Code](https://claude.ai/code)