### PR TITLE
fix(issue#75): Git MCPサーバーをnpmではなくpipでインストールするよう修正

### DIFF
--- a/container/claudecode/forpasipde/amazonlinux.Dockerfile
+++ b/container/claudecode/forpasipde/amazonlinux.Dockerfile
@@ -26,7 +26,7 @@ RUN ln -sf /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
     echo "Asia/Tokyo" > /etc/timezone
     
 # 必要なツールのインストール
-RUN python3 -m pip install pytest black flake8 mypy && \
+RUN python3 -m pip install pytest black flake8 mypy mcp-server-git && \
     npm install -g uv
 
 # nvmのインストール
@@ -87,15 +87,14 @@ RUN npm install -g @anthropic-ai/claude-code \
     && npm install -g @modelcontextprotocol/server-gitlab \
     && npm install -g @modelcontextprotocol/server-filesystem \
     && npm install -g @modelcontextprotocol/server-sequential-thinking \
-    && npm install -g mcp-server-sqlite-npx \
-    && npm install -g @cyanheads/git-mcp-server
+    && npm install -g mcp-server-sqlite-npx
     
 # MCPサーバーパッケージが正しくインストールされたか確認
 RUN npx @modelcontextprotocol/server-gitlab --version || echo "GitLab MCP server package installed" && \
     npx @modelcontextprotocol/server-filesystem --version || echo "Filesystem MCP server package installed" && \
     npx @modelcontextprotocol/server-sequential-thinking --version || echo "Sequential Thinking MCP server package installed" && \
     npx mcp-server-sqlite-npx --version || echo "SQLite MCP server package installed" && \
-    npx @cyanheads/git-mcp-server --version || echo "Git MCP server package installed"
+    python3 -m mcp_server_git --version || echo "Git MCP server package installed"
 
 # Claudeユーザーのホームディレクトリに環境設定を追加
 RUN echo 'export PATH=$PATH:/usr/local/bin' >> ~/.bashrc

--- a/container/claudecode/forpasipde/debian.Dockerfile
+++ b/container/claudecode/forpasipde/debian.Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update && apt-get install -y \
     tzdata \
     && rm -rf /var/lib/apt/lists/*
 
-RUN python3 -m pip install --break-system-packages pytest black flake8 mypy && \
+RUN python3 -m pip install --break-system-packages pytest black flake8 mypy mcp-server-git && \
     npm install -g uv
 
 # タイムゾーンのAsia/Tokyo設定
@@ -57,15 +57,14 @@ RUN npm install -g @anthropic-ai/claude-code \
     && npm install -g @modelcontextprotocol/server-gitlab \
     && npm install -g @modelcontextprotocol/server-filesystem \
     && npm install -g @modelcontextprotocol/server-sequential-thinking \
-    && npm install -g mcp-server-sqlite-npx \
-    && npm install -g @cyanheads/git-mcp-server
+    && npm install -g mcp-server-sqlite-npx
 
 # MCPサーバーパッケージが正しくインストールされたか確認
 RUN npx @modelcontextprotocol/server-gitlab --version || echo "GitLab MCP server package installed" && \
     npx @modelcontextprotocol/server-filesystem --version || echo "Filesystem MCP server package installed" && \
     npx @modelcontextprotocol/server-sequential-thinking --version || echo "Sequential Thinking MCP server package installed" && \
     npx mcp-server-sqlite-npx --version || echo "SQLite MCP server package installed" && \
-    npx @cyanheads/git-mcp-server --version || echo "Git MCP server package installed"
+    python3 -m mcp_server_git --version || echo "Git MCP server package installed"
 
 # MCPサーバー登録スクリプトをコンテナ内にコピー
 COPY setup_mcp_servers.sh /app/setup_mcp_servers.sh

--- a/container/claudecode/forpasipde/node-slim.Dockerfile
+++ b/container/claudecode/forpasipde/node-slim.Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y \
 
 # 必要なツールのインストール
 RUN gem install tmuxinator --no-document && \
-    python3 -m pip install --break-system-packages pytest black flake8 mypy && \
+    python3 -m pip install --break-system-packages pytest black flake8 mypy mcp-server-git && \
     npm install -g uv
 
 # タイムゾーンのAsia/Tokyo設定
@@ -50,15 +50,14 @@ RUN npm install -g @anthropic-ai/claude-code \
     && npm install -g @modelcontextprotocol/server-gitlab \
     && npm install -g @modelcontextprotocol/server-filesystem \
     && npm install -g @modelcontextprotocol/server-sequential-thinking \
-    && npm install -g mcp-server-sqlite-npx \
-    && npm install -g @cyanheads/git-mcp-server
+    && npm install -g mcp-server-sqlite-npx
 
 # MCPサーバーパッケージが正しくインストールされたか確認
 RUN npx @modelcontextprotocol/server-gitlab --version || echo "GitLab MCP server package installed" && \
     npx @modelcontextprotocol/server-filesystem --version || echo "Filesystem MCP server package installed" && \
     npx @modelcontextprotocol/server-sequential-thinking --version || echo "Sequential Thinking MCP server package installed" && \
     npx mcp-server-sqlite-npx --version || echo "SQLite MCP server package installed" && \
-    npx @cyanheads/git-mcp-server --version || echo "Git MCP server package installed"
+    python3 -m mcp_server_git --version || echo "Git MCP server package installed"
 
 # MCPサーバー登録スクリプトをコンテナ内にコピー
 COPY setup_mcp_servers.sh /app/setup_mcp_servers.sh

--- a/container/claudecode/forpasipde/setup_mcp_servers.sh
+++ b/container/claudecode/forpasipde/setup_mcp_servers.sh
@@ -74,8 +74,8 @@ if [ "${MCP_GIT_ENABLED:-0}" = "1" ]; then
     echo "5. Git MCPサーバーを登録します..."
     claude mcp add-json git "$(cat <<EOF
 {
-  "command": "npx",
-  "args": ["-y", "@cyanheads/git-mcp-server"],
+  "command": "python3",
+  "args": ["-m", "mcp_server_git"],
   "env": {}
 }
 EOF


### PR DESCRIPTION
- @cyanheads/git-mcp-serverを削除
- pip経由でmcp-server-gitをインストールするよう変更
- setup_mcp_servers.shでGit MCPサーバー登録コマンドをPython形式に変更
- MCPサーバー検証コマンドをpython3 -m mcp_server_gitに変更

🤖 Generated with [Claude Code](https://claude.ai/code)