### PR TITLE
feat: Mattermostコンテナの追加

### DIFF
--- a/container/mattermost/Dockerfile
+++ b/container/mattermost/Dockerfile
@@ -1,0 +1,72 @@
+FROM ubuntu:22.04 as builder
+
+# 環境変数の設定
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Asia/Tokyo
+
+# 必要なパッケージのインストール
+RUN apt-get update && apt-get install -y \
+    wget \
+    curl \
+    gnupg2 \
+    apt-transport-https \
+    ca-certificates \
+    tzdata \
+    && rm -rf /var/lib/apt/lists/*
+
+# Mattermostのバージョンと環境設定
+ENV MATTERMOST_VERSION=9.5.1
+ENV MATTERMOST_HOME=/opt/mattermost
+WORKDIR /opt
+
+# Mattermostのダウンロードと展開
+RUN wget -q https://releases.mattermost.com/${MATTERMOST_VERSION}/mattermost-${MATTERMOST_VERSION}-linux-amd64.tar.gz \
+    && tar -xzf mattermost-${MATTERMOST_VERSION}-linux-amd64.tar.gz \
+    && rm mattermost-${MATTERMOST_VERSION}-linux-amd64.tar.gz \
+    && mkdir -p ${MATTERMOST_HOME}/data \
+    && mkdir -p ${MATTERMOST_HOME}/plugins \
+    && mkdir -p ${MATTERMOST_HOME}/client/plugins \
+    && mkdir -p ${MATTERMOST_HOME}/config
+
+# メインイメージ
+FROM ubuntu:22.04
+
+# 環境変数の設定
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Asia/Tokyo
+ENV MATTERMOST_HOME=/opt/mattermost
+ENV PATH=${MATTERMOST_HOME}/bin:${PATH}
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+# 必要なパッケージのインストール
+RUN apt-get update && apt-get install -y \
+    postgresql-client \
+    jq \
+    git \
+    openssh-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# Mattermostのファイルをビルダーステージからコピー
+COPY --from=builder /opt/mattermost /opt/mattermost
+
+# ユーザー作成と権限設定
+RUN adduser --disabled-password --gecos "" mattermost \
+    && chown -R mattermost:mattermost ${MATTERMOST_HOME} \
+    && chmod -R 755 ${MATTERMOST_HOME}
+
+# 設定ファイルの準備
+WORKDIR ${MATTERMOST_HOME}
+RUN mkdir -p ${MATTERMOST_HOME}/config-init
+COPY config.json ${MATTERMOST_HOME}/config-init/
+
+# root権限の起動スクリプトを作成
+COPY root-entrypoint.sh /root-entrypoint.sh
+RUN chmod +x /root-entrypoint.sh
+
+# コンテナ起動時の設定
+EXPOSE 8065
+VOLUME ["${MATTERMOST_HOME}/data", "${MATTERMOST_HOME}/logs", "${MATTERMOST_HOME}/config"]
+
+# Mattermostサーバーの起動
+ENTRYPOINT ["/root-entrypoint.sh"]

--- a/container/mattermost/README.md
+++ b/container/mattermost/README.md
@@ -1,0 +1,137 @@
+# Mattermost & GitLab 連携コンテナ
+
+## 概要
+このリポジトリには、Mattermostをコンテナ化し、GitLabと連携するための設定が含まれています。
+正常に動作するよう設定されたMattermostサーバー（バージョン9.5.1）とPostgreSQLデータベースを提供します。
+
+## ファイル構成
+- `Dockerfile`: Mattermostコンテナのビルド定義
+- `config.json`: Mattermostの設定ファイル
+- `podman-compose.yml`: コンテナオーケストレーション定義
+- `root-entrypoint.sh`: コンテナ起動スクリプト
+
+## 前提条件
+- GitLabコンテナがすでに起動している（ホスト名: gitlab）
+- podmanとpodman-composeがインストールされている
+- ネットワーク接続に制限があり、運用環境ではダウンロード不可
+
+## セットアップ手順
+
+### 1. ネットワークの作成
+
+```bash
+# Mattermostネットワークの作成
+podman network create mattermost-network
+
+# GitLabネットワークが存在しない場合は作成
+podman network create gitlab-network
+```
+
+### 2. コンテナのビルドと起動
+
+```bash
+cd /path/to/mattermost
+podman-compose build
+podman-compose up -d
+```
+
+### 3. Mattermostへのアクセス
+
+ブラウザで`http://localhost:8001`にアクセスし、管理者アカウントを作成してください。
+
+## GitLab連携の設定手順
+
+### 1. GitLabでアプリケーションを作成
+
+GitLabにログイン後、以下の手順でMattermost用のOAuthアプリケーションを作成します：
+
+1. GitLabの管理者アカウントでログイン
+2. 「Admin Area」（管理エリア）を選択
+3. 「Applications」（アプリケーション）を選択
+4. 「New Application」（新しいアプリケーション）をクリック
+5. 以下の情報を入力：
+   - Name: Mattermost
+   - Redirect URI: 
+     - `http://localhost:8001/signup/gitlab/complete`
+     - `http://localhost:8001/login/gitlab/complete`
+   - Scopes: api, read_user
+6. 「Submit」（送信）をクリック
+7. 表示される「Application ID」と「Secret」を記録（これらの値は後で必要）
+
+### 2. SSH鍵の作成（GitLabリポジトリのクローン用）
+
+```bash
+# コンテナ内でSSH鍵を生成
+podman exec -it mattermost-app bash
+mkdir -p /opt/mattermost/.ssh
+ssh-keygen -t rsa -b 4096 -C "mattermost@example.com" -f /opt/mattermost/.ssh/id_rsa -N ""
+
+# 公開鍵の内容を表示（GitLabに登録するため）
+cat /opt/mattermost/.ssh/id_rsa.pub
+```
+
+この公開鍵をGitLabの「Admin Area」→「Users」→該当ユーザー→「SSH Keys」に追加します。
+
+### 3. Mattermostの設定変更
+
+1. `config.json`ファイルの`GitLabSettings`セクションを編集：
+
+```json
+"GitLabSettings": {
+  "Enable": true,
+  "Secret": "GitLabで取得したSecret",
+  "Id": "GitLabで取得したApplication ID",
+  "Scope": "api read_user",
+  "AuthEndpoint": "http://gitlab:3000/oauth/authorize",
+  "TokenEndpoint": "http://gitlab:3000/oauth/token",
+  "UserApiEndpoint": "http://gitlab:3000/api/v4/user",
+  "DiscoveryEndpoint": ""
+}
+```
+
+## コンテナの停止
+
+```bash
+cd /path/to/mattermost
+podman-compose down
+```
+
+## GitLabプラグインの有効化
+
+1. Mattermostの「System Console」→「Plugins」→「Management」に移動
+2. GitLabプラグインを探して「Enable」をクリック
+3. 「System Console」→「Plugins」→「GitLab」に移動
+4. GitLabの設定を確認、必要に応じて修正
+5. 設定を保存
+
+## トラブルシューティング
+
+### 一般的な問題
+
+- ログの確認: `podman logs mattermost-app`
+- コンテナ内でのデバッグ: `podman exec -it mattermost-app bash`
+
+### Mattermostが起動しない場合
+
+1. 環境変数PATHが正しく設定されているか確認：
+   ```bash
+   podman exec -it mattermost-app env | grep PATH
+   ```
+
+2. バイナリファイルの権限を確認：
+   ```bash
+   podman exec -it mattermost-app ls -la /opt/mattermost/bin/
+   ```
+
+### GitLab連携が機能しない場合
+
+1. ネットワーク接続を確認：
+   ```bash
+   # pingコマンドのインストール
+   podman exec -it mattermost-app apt-get update && podman exec -it mattermost-app apt-get install -y iputils-ping
+   
+   # GitLabへの疎通確認
+   podman exec -it --privileged mattermost-app ping -c 2 gitlab
+   ```
+
+2. `podman-compose.yml`のネットワーク設定を確認

--- a/container/mattermost/config.json
+++ b/container/mattermost/config.json
@@ -1,0 +1,87 @@
+{
+  "ServiceSettings": {
+    "SiteURL": "http://localhost:8001",
+    "ListenAddress": ":8065",
+    "ConnectionSecurity": "",
+    "TLSCertFile": "",
+    "TLSKeyFile": "",
+    "UseLetsEncrypt": false,
+    "EnableDeveloper": false,
+    "EnableSecurityFixAlert": true,
+    "EnableInsecureOutgoingConnections": false
+  },
+  "TeamSettings": {
+    "SiteName": "Mattermost",
+    "MaxUsersPerTeam": 100,
+    "EnableUserCreation": true,
+    "EnableOpenServer": true,
+    "RestrictDirectMessage": "any"
+  },
+  "SqlSettings": {
+    "DriverName": "postgres",
+    "DataSource": "postgres://mmuser:mmuser_password@postgres:5432/mattermost?sslmode=disable&connect_timeout=10",
+    "MaxIdleConns": 20,
+    "MaxOpenConns": 300,
+    "Trace": false,
+    "AtRestEncryptKey": "7rAh6iwQCkV4cA1Gsg3fgGOXJAQ43QVg"
+  },
+  "LogSettings": {
+    "EnableConsole": true,
+    "ConsoleLevel": "INFO",
+    "EnableFile": true,
+    "FileLevel": "INFO",
+    "FileFormat": "json",
+    "FileLocation": "/opt/mattermost/logs"
+  },
+  "FileSettings": {
+    "EnableFileAttachments": true,
+    "EnableMobileUpload": true,
+    "EnableMobileDownload": true,
+    "MaxFileSize": 52428800,
+    "DriverName": "local",
+    "Directory": "/opt/mattermost/data",
+    "EnablePublicLink": false,
+    "PublicLinkSalt": "A705AklYF8MFDOfcwh3I488G8vtLlVip"
+  },
+  "EmailSettings": {
+    "EnableSignUpWithEmail": true,
+    "EnableSignInWithEmail": true,
+    "EnableSignInWithUsername": true,
+    "SendEmailNotifications": false,
+    "RequireEmailVerification": false,
+    "SMTPUsername": "",
+    "SMTPPassword": "",
+    "SMTPServer": "",
+    "SMTPPort": "",
+    "ConnectionSecurity": "",
+    "InviteSalt": "bjlSR4QqkXFBr7TP4oDzlfZmcNuH9YoS",
+    "PasswordResetSalt": "vZ4DcKyVVRlKHHJpexcuXzojkE5PZ5eL",
+    "SendPushNotifications": false,
+    "PushNotificationContents": "generic",
+    "EnableEmailBatching": false
+  },
+  "RateLimitSettings": {
+    "Enable": false,
+    "PerSec": 10,
+    "MaxBurst": 100,
+    "MemoryStoreSize": 10000,
+    "VaryByRemoteAddr": true,
+    "VaryByUser": false
+  },
+  "PluginSettings": {
+    "Enable": true,
+    "EnableUploads": true,
+    "Directory": "/opt/mattermost/plugins",
+    "ClientDirectory": "/opt/mattermost/client/plugins"
+  },
+  "GitLabSettings": {
+    "Enable": true,
+    "Secret": "generate_a_secure_token_here",
+    "Id": "your_gitlab_application_id",
+    "Scope": "api read_user",
+    "AuthEndpoint": "http://gitlab:3000/oauth/authorize",
+    "TokenEndpoint": "http://gitlab:3000/oauth/token",
+    "UserApiEndpoint": "http://gitlab:3000/api/v4/user",
+    "DiscoveryEndpoint": ""
+  }
+}

--- a/container/mattermost/podman-compose.yml
+++ b/container/mattermost/podman-compose.yml
@@ -1,0 +1,53 @@
+version: '3'
+
+networks:
+  mattermost-network:
+    external: true
+  gitlab-network:
+    external: true
+
+services:
+  postgres:
+    image: postgres:15
+    container_name: mattermost-postgres
+    environment:
+      - POSTGRES_USER=mmuser
+      - POSTGRES_PASSWORD=mmuser_password
+      - POSTGRES_DB=mattermost
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    restart: unless-stopped
+    networks:
+      - mattermost-network
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "mmuser"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  mattermost:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: mattermost-app
+    depends_on:
+      - postgres
+    environment:
+      - MM_SQLSETTINGS_DRIVERNAME=postgres
+      - MM_SQLSETTINGS_DATASOURCE=postgres://mmuser:mmuser_password@postgres:5432/mattermost?sslmode=disable&connect_timeout=10
+    volumes:
+      - mattermost-data:/opt/mattermost/data
+      - mattermost-logs:/opt/mattermost/logs
+      - mattermost-config:/opt/mattermost/config
+    ports:
+      - "8001:8065"
+    restart: unless-stopped
+    networks:
+      - mattermost-network
+      - gitlab-network
+
+volumes:
+  postgres-data:
+  mattermost-data:
+  mattermost-logs:
+  mattermost-config:

--- a/container/mattermost/root-entrypoint.sh
+++ b/container/mattermost/root-entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+# デバッグ情報の表示
+echo "Debug: PATH=$PATH"
+echo "Debug: MATTERMOST_HOME=$MATTERMOST_HOME"
+ls -la /opt/mattermost/bin/
+
+# 設定ファイルのパーミッション設定
+rm -rf /opt/mattermost/config/*
+mkdir -p /opt/mattermost/config
+chown -R mattermost:mattermost /opt/mattermost
+chmod -R 777 /opt/mattermost/config
+chmod -R 777 /opt/mattermost/logs
+chmod -R 777 /opt/mattermost/data
+chmod -R 777 /opt/mattermost/client
+chmod -R 777 /opt/mattermost/plugins
+
+# 設定ファイルをコピー
+cp /opt/mattermost/config-init/config.json /opt/mattermost/config/config.json
+
+# 設定ファイルのパーミッション設定
+chmod 666 /opt/mattermost/config/config.json
+chown mattermost:mattermost /opt/mattermost/config/config.json
+
+# PATHを明示的に設定
+export PATH="/opt/mattermost/bin:$PATH"
+
+# mattermostユーザーとしてサーバーを起動
+exec su -c "export PATH=/opt/mattermost/bin:\$PATH && exec /opt/mattermost/bin/mattermost" mattermost


### PR DESCRIPTION
## 概要
MattermostコンテナをGitLab連携機能付きで実装しました。

### 主な実装内容
- Mattermostサーバー（バージョン9.5.1）のコンテナ作成
- PostgreSQLデータベース（バージョン15）との連携設定
- GitLab統合のための設定とプラグイン有効化
- ポート8001でのサービス公開
- podman-composeを使用したコンテナオーケストレーション

### 技術的詳細
- マルチステージビルドを採用し、イメージサイズを最適化
- ボリューム設定で永続的なデータ管理を実現
- GitLabネットワークとの接続設定
- PATH環境変数の適切な設定による安定稼働

## テスト内容
- コンテナのビルドと起動確認
- APIエンドポイントでの疎通確認 (`curl http://localhost:8001/api/v4/system/ping`)
- WebアプリケーションのHTTPアクセス確認
- ボリュームマウントの正常動作確認
- ネットワーク接続テスト

🤖 Generated with [Claude Code](https://claude.ai/code)