### PR TITLE
トップページの背景色を淡い青色に変更

### DIFF
--- a/container/claudecode/studyGIt/src/app/globals.css
+++ b/container/claudecode/studyGIt/src/app/globals.css
@@ -1,5 +1,6 @@
 :root {
-  --background: #f5f5f5;
+  /* 変更前の色: #f5f5f5 (淡いグレー) */
+  --background: #e6f0ff; /* 淡い青色 */
   --foreground: #333;
   --primary: #6366f1;
   --secondary: #f59e0b;


### PR DESCRIPTION
## 概要
issue #81 の対応として、トップページの背景色を淡いグレーから淡い青色(#e6f0ff)に変更しました。

## 変更内容
- `src/app/globals.css` の CSS変数 `--background` の値を `#f5f5f5`(淡いグレー) から `#e6f0ff`(淡い青色) に変更

## スクリーンショット
実際の表示は確認していませんが、次のように変更されています：
- 変更前：淡いグレー (#f5f5f5)
- 変更後：淡い青色 (#e6f0ff)

## テスト
- [x] ローカル環境でビルドが正常に完了することを確認
- [x] コンテナ内のCSSファイルに変更が反映されていることを確認

## 関連Issue
Closes #81