### PR TITLE
トップページの背景色を淡い赤色(#ffebee)に変更

### DIFF
--- a/container/claudecode/studyGIt/src/app/globals.css
+++ b/container/claudecode/studyGIt/src/app/globals.css
@@ -1,5 +1,5 @@
 :root {
-  --background: #f5f5f5;
+  --background: #ffebee;
   --foreground: #333;
   --primary: #6366f1;
   --secondary: #f59e0b;


### PR DESCRIPTION
## 概要
Issue #82に基づき、GitPlaygroundのトップページ背景色を淡い赤色(#ffebee)に変更しました。

## 変更内容
- `src/app/globals.css`ファイル内の`:root`変数セクションにある`--background`の値を`#f5f5f5`（薄いグレー）から`#ffebee`（淡い赤色）に変更

## 選定した色について
- Material DesignのRed 50カラー（`#ffebee`）を採用
- 非常に淡い赤色で、テキストの可読性を確保しながら視覚的な変化をもたらす
- WCAGアクセシビリティ基準に適合するコントラスト比を維持

## テスト
- 変更はCSS変数のみの修正であり、コンポーネント構造や機能に影響を与えません
- グローバルCSSの変更のため、App RouterとPages Router両方のトップページに適用されます

## スクリーンショット
*変更の視覚的な確認はレビュー時にお願いします*

## 関連Issue
- Closes #82