### PR TITLE
トップページの背景色を黄色(#FFFDE7)に変更

### DIFF
--- a/container/claudecode/studyGIt/src/app/globals.css
+++ b/container/claudecode/studyGIt/src/app/globals.css
@@ -1,6 +1,7 @@
 :root {
   /* mainでは #ffebee でしたが、issue #81に従い淡い青色に変更 */
-  --background: #e6f0ff; /* 淡い青色 */
+  /* issue #87に従い淡い青色から黄色に変更 */
+  --background: #FFFDE7; /* 淡い黄色 */
   --foreground: #333;
   --primary: #6366f1;
   --secondary: #f59e0b;


### PR DESCRIPTION
## 概要
Issue #87に対応し、GitPlaygroundのトップページの背景色を淡い黄色(#FFFDE7)に変更しました。

## 変更内容
- `src/app/globals.css`ファイルの`:root`セクションにある`--background`変数の値を`#e6f0ff`(淡い青色)から`#FFFDE7`(淡い黄色)に変更しました。
- コメントを追加して変更の目的と対応するIssueを明記しました。

## テスト方法
1. podman-composeでコンテナを起動
2. ブラウザでhttp://localhost:3000/にアクセス
3. トップページの背景色が黄色(#FFFDE7)になっていることを確認
4. レスポンシブ表示でも正しく表示されていることを確認

## スクリーンショット
なし（シンプルな背景色の変更のため）