### PR TITLE
トップページの背景色を紫色に変更

### DIFF
--- a/container/claudecode/studyGIt/src/app/globals.css
+++ b/container/claudecode/studyGIt/src/app/globals.css
@@ -1,6 +1,6 @@
 :root {
-  /* mainでは #ffebee でしたが、issue #81に従い淡い青色に変更 */
-  --background: #e6f0ff; /* 淡い青色 */
+  /* mainでは #ffebee でしたが、issue #86に従い紫色に変更 */
+  --background: #f3e5f5; /* 紫色 */
   --foreground: #333;
   --primary: #6366f1;
   --secondary: #f59e0b;


### PR DESCRIPTION
## 概要
Issue #86 に基づき、Git Playgroundのトップページの背景色を紫色に変更しました。

## 変更内容
- 背景色を淡い青色(`#e6f0ff`)から紫色(`#f3e5f5`)に変更
- コメントを適切に更新

## テスト方法
1. プロジェクトをクローンする
2. このブランチに切り替える
3. `podman-compose up --build`を実行
4. ブラウザで`http://localhost:3000`にアクセス
5. トップページの背景色が紫色になっていることを確認

## スクリーンショット
（実際のUIではマテリアルデザインの紫色パレット100レベル相当の色合いが適用されています）

## 関連Issue
Closes #86