### PR TITLE
トップページの背景色を緑色に変更

### DIFF
--- a/container/claudecode/studyGIt/src/app/globals.css
+++ b/container/claudecode/studyGIt/src/app/globals.css
@@ -1,6 +1,6 @@
 :root {
-  /* mainでは #ffebee でしたが、issue #86で紫色になりましたが、issue #87に従い黄色に変更 */
-  --background: #FFFDE7; /* 淡い黄色 */
+  /* mainでは #ffebee でしたが、issue #86で紫色に、issue #87で黄色に、そしてissue #91で緑色に変更 */
+  --background: #E8F5E9; /* 淡い緑色 */
   --foreground: #333;
   --primary: #6366f1;
   --secondary: #f59e0b;


### PR DESCRIPTION
## 概要
Issue #91に基づき、Git Playgroundのトップページの背景色を黄色から緑色(#E8F5E9)に変更しました。

## 変更内容
- `/src/app/globals.css`の`:root`セクションにある`--background`変数の値を`#FFFDE7`(淡い黄色)から`#E8F5E9`(淡い緑色)に変更
- 変更履歴コメントを更新

## 動作確認済み
- podman-composeで起動し、ローカル環境でトップページの背景色が緑色になっていることを確認
- その他の機能に影響がないことを確認

## スクリーンショット
なし（見た目の変更のみ）

fixes #91