### PR TITLE
トップページの背景色を赤色に変更

### DIFF
--- a/container/claudecode/studyGIt/src/app/globals.css
+++ b/container/claudecode/studyGIt/src/app/globals.css
@@ -1,6 +1,6 @@
 :root {
-  /* mainでは #ffebee でしたが、issue #86で紫色になりましたが、issue #87に従い黄色に変更 */
-  --background: #FFFDE7; /* 淡い黄色 */
+  /* mainでは #ffebee でしたが、issue #86で紫色になり、issue #87で黄色に変更されましたが、issue #90に従い赤色に変更 */
+  --background: #FFEBEE; /* 淡い赤色 */
   --foreground: #333;
   --primary: #6366f1;
   --secondary: #f59e0b;


### PR DESCRIPTION
## 概要
Issue #90 に対応し、トップページの背景色を黄色から赤色に変更しました。

## 変更内容
- `src/app/globals.css` の `--background` 変数の値を `#FFFDE7`（黄色）から `#FFEBEE`（淡い赤色）に変更
- コメントも更新してIssue番号の履歴を反映

## テスト方法
1. `podman-compose up --build` でアプリケーションを起動
2. ブラウザで `http://localhost:3000` にアクセス
3. トップページの背景色が赤色になっていることを確認

## スクリーンショット
なし

## 関連Issue
Close #90