### PR TITLE
Fix agents directory path in Dockerfile

### DIFF
--- a/container/claudecode/forpasipde/node-slim.Dockerfile
+++ b/container/claudecode/forpasipde/node-slim.Dockerfile
@@ -69,7 +69,7 @@ USER claudeuser
 RUN mkdir -p ~/.claude
 
 # agentsディレクトリを~/.claudeにコピー
-COPY --chown=claudeuser:claudeuser agents /home/claudeuser/.claude/agents
+COPY --chown=claudeuser:claudeuser ../agents /home/claudeuser/.claude/agents
 
 # /appディレクトリの所有者を変更
 USER root


### PR DESCRIPTION
## Summary
Fixed the agents directory path in the Dockerfile to correctly reference the relocated agents folder.

## Changes Made
- Updated `COPY` command from `agents` to `../agents` in `forpasipde/node-slim.Dockerfile`
- This fixes the build issue caused by the agents folder being moved to the parent directory
- Ensures proper agent files are copied to `~/.claude/agents` within the container

## Problem Solved
The previous Docker build was failing because the agents folder was moved from the current directory to the parent directory, but the Dockerfile was still referencing the old location.

## Test Plan
- [ ] Verify Docker build completes successfully
- [ ] Confirm agents files are properly copied to `~/.claude/agents`
- [ ] Test container startup and agent functionality

## Related Issues
This addresses the file structure changes made in previous commits where the agents folder was reorganized.

🤖 Generated with [Claude Code](https://claude.ai/code)